### PR TITLE
chore: sync with dembrandt v0.12.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dembrandt-skills",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Shareable UX and design system skills for AI agents — Gestalt, typography, modular scale, and more.",
   "keywords": [
     "ux",


### PR DESCRIPTION
Automated sync triggered by [dembrandt v0.12.1](manual trigger).

- Bumped `dembrandt-skills` patch version
- Updated CLI version references in skill files