### PR TITLE
chore: sync with dembrandt v0.19.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dembrandt-skills",
-  "version": "0.3.8",
+  "version": "0.3.9",
   "description": "Shareable UX and design system skills for AI agents — Gestalt, typography, modular scale, and more.",
   "keywords": [
     "ux",


### PR DESCRIPTION
Automated sync triggered by [dembrandt v0.19.4](https://github.com/dembrandt/dembrandt/releases/tag/v0.19.4).

- Bumped `dembrandt-skills` patch version
- Updated CLI version references in skill files

**⚠ Manual check required before merging**
This automation only updates version numbers. If this release added or changed CLI flags, update `skills/extract-design/SKILL.md` manually:
- Flags reference table
- Anti-Bot section if behavior changed

See full checklist: [dembrandt/CLAUDE.md](https://github.com/dembrandt/dembrandt/blob/main/CLAUDE.md)