### PR TITLE
Add Claude-native UI typography & small-component guidance

### DIFF
--- a/skills/component-family-consistency/SKILL.md
+++ b/skills/component-family-consistency/SKILL.md
@@ -192,7 +192,21 @@ export function Kbd({ children }: { children: ReactNode }) {
 
 ---
 
-## Gradients in Components
+## Alignment on a Line
+
+When a single line mixes element types — a label, a badge, a status dot, a value, an icon — they must read as one aligned row, not a jumble of differently-sized pieces.
+
+- **Same type size on the line.** Text sitting next to a badge or chip should share the same typeface size as the surrounding text. A badge should not silently shrink or enlarge the effective text size of its row. Use `leading-none` and `align-middle` (as in the chip `BASE` above) so every element sits on a shared centre line.
+- **Centre status indicators on the line.** A traffic-light status dot (red/amber/green) must be **vertically centred against the text it annotates**, not sitting on the baseline or floating high. Align it to the cap-height centre of the adjacent label.
+- **One baseline, one rhythm.** Mixed badges + text + icons on a row should align to a single optical centre line. If elements jump up and down, the row reads as broken even when each piece is individually fine.
+
+## Small Component Restraint
+
+The smaller the component, the less it can carry. Restraint that looks plain at large sizes is what keeps small components legible.
+
+- **Avoid multi-border / boxed-in containers.** In small components, do not stack multiple bordered layers (a bordered chip inside a bordered cell inside a bordered card). Each border adds visual weight that a small element cannot absorb. Prefer a single border, or none — use background fill or spacing instead. This is the small-scale companion to the 2-Step border rule.
+- **Don't over-complicate with multiple icons.** A small component should carry **at most one icon**. Two or three icons crammed into a pill, badge, or list row create clutter and ambiguity about which icon is the actionable one. If you need more, the component has outgrown its size — promote it to a larger pattern.
+- **If you're about to build a multi-card-container design, pivot.** Nesting cards inside cards inside containers (card-in-card-in-card) signals that grouping is being solved with boxes instead of spacing and hierarchy. Before committing, step back: flatten the nesting, use whitespace and headings to group (see [[gestalt-ui-organisation]]), and reserve the card metaphor for the outermost meaningful container only.
 
 If the brand uses gradients, apply them consistently:
 
@@ -213,3 +227,8 @@ If the brand uses gradients, apply them consistently:
 - [ ] Are inline labels, statuses, code tokens, keyboard hints, and metrics separate components — not variants of a generic Badge?
 - [ ] Do chip/badge components use `em`-relative sizing so they scale with their text context?
 - [ ] Is chip colour defined in CSS classes (not inline props) so light/dark lives in one place?
+- [ ] On rows mixing text, badges, and icons, does everything share one type size and centre line?
+- [ ] Are status/traffic-light indicators vertically centred against their label?
+- [ ] Do small components avoid stacked/nested borders (boxed-in look)?
+- [ ] Do small components carry at most one icon?
+- [ ] Has card-in-card-in-card nesting been flattened in favour of spacing and hierarchy?

--- a/skills/gestalt-ui-organisation/SKILL.md
+++ b/skills/gestalt-ui-organisation/SKILL.md
@@ -58,6 +58,11 @@ Elements that are close together are perceived as a group.
 
 **Example:** A toolbar with `[Cut] [Copy] [Paste]` grouped tightly, then a wider gap before `[Undo] [Redo]`, communicates two distinct command groups without any visual divider.
 
+#### Prefer whitespace over separator lines
+Default to **whitespace, not divider lines**, as the grouping indicator. Most separators in a UI are doing work that spacing could do better — they add visual noise and a "boxed-in" feel without adding information. When reviewing, remove the majority of line separators and let proximity carry the grouping.
+
+One caveat: a line occupies almost no space, so removing it often leaves groups too close together. **Removing separators usually means adding spacing** — budget for the extra whitespace (and occasionally a subtle background shift or heading) rather than just deleting the line and leaving the layout cramped.
+
 ### 2. Similarity
 Elements that look alike are perceived as related.
 
@@ -104,6 +109,7 @@ When reviewing a UI layout for Gestalt compliance:
 - [ ] Is proximity used as the primary grouping signal (not only borders/lines)?
 - [ ] Do visually similar elements share a functional purpose?
 - [ ] Are unrelated groups separated by meaningful whitespace?
+- [ ] Have unnecessary divider lines been removed in favour of whitespace (with spacing added to compensate)?
 - [ ] Does visual hierarchy match interaction hierarchy (primary > secondary > tertiary)?
 - [ ] Are destructive or irreversible actions visually distinct from constructive ones?
 - [ ] Is the figure/ground contrast sufficient for all interactive elements?

--- a/skills/modular-scale-typography/SKILL.md
+++ b/skills/modular-scale-typography/SKILL.md
@@ -138,6 +138,23 @@ With a modular scale, every size step carries the same visual weight of change. 
 
 In the modular scale, this means the base (`step 0`) should be 16px, and negative steps (step -1, step -2) should be used only for genuinely secondary content — never for body copy or primary labels.
 
+**The 1% heuristic.** Sub-16px text should be the rare exception, not a habit. As a rule of thumb, keep **at most ~1% of the text on a page below 16px**, and never below 14px. If a layout pushes large amounts of text down to 13–14px to fit, the problem is layout density, not type size — reduce what is shown rather than shrinking the type.
+
+## Type Rendering Details
+
+Size and ratio set the structure; these details determine whether the type actually reads well on screen.
+
+### Letter Spacing
+- **Body and default text:** keep letter-spacing at or near `0`. Resist adding tracking to running text — it slows reading and makes the type feel loose and uncommitted. When in doubt, use less.
+- **Uppercase and small labels:** uppercase is the one place to *add* tracking (`0.03em`–`0.08em`), because capitals are visually tighter and need air to stay legible at small sizes.
+- The pattern: **less letter-spacing on lowercase body, more on uppercase labels** — never a blanket value across the whole UI.
+
+### Weight on Dark Backgrounds
+White (or light) text on a dark background appears optically **thinner** than the same weight on a light background — a halation effect where the bright type bleeds into the dark field. Compensate by stepping up one weight: if a regular (400) weight works for body on light, use a **medium or semibold cut for the equivalent text on dark**. This keeps perceived weight consistent across light and dark modes instead of dark-mode text looking frail.
+
+### Monospace
+Monospace is for technical content where character alignment matters — code, IDs, numeric tables, diffs. **Do not use it as a default UI typeface, and avoid monospace + uppercase together** (the even widths plus tall capitals are hard to scan). Keep monospace scoped to the content that genuinely benefits from fixed-width rendering.
+
 ## Type Scale by Page Context
 
 **Landing pages and marketing surfaces** benefit from large, expressive type — steps +4 to +6 for headlines create drama and brand presence.
@@ -218,6 +235,10 @@ Never shrink the scale from the bottom. Body text at 16px is already a floor —
 - [ ] Is the base size 16px or larger?
 - [ ] Is 14px used only for secondary/metadata text, never for body copy?
 - [ ] Is nothing below 14px used anywhere in the UI?
+- [ ] Is sub-16px text kept to a small fraction (~1%) of the page, not the default?
+- [ ] Is body letter-spacing at/near 0, with extra tracking reserved for uppercase labels?
+- [ ] Does light-on-dark text use a slightly heavier cut to compensate for halation?
+- [ ] Is monospace scoped to technical content, never used as a default or with uppercase?
 - [ ] Is there at least 3–4 distinct steps between body text and the largest heading?
 - [ ] Are adjacent steps (e.g. body vs. label) different enough to be distinguishable at a glance?
 - [ ] Are font size tokens named by role (`--text-body`, `--text-h1`) or step (`--text-base`, `--text-2xl`), not by raw pixel value?
@@ -236,3 +257,6 @@ Never shrink the scale from the bottom. Body text at 16px is already a floor —
 | Arbitrary sizes with no relationship (13, 18, 27, 36px) | No underlying logic — hierarchy feels accidental | Regenerate from a single base and ratio |
 | Pixel values hard-coded in components instead of tokens | Scale changes require hunting through every file | Define once as CSS custom properties or design tokens |
 | Same scale used for display headings and dense data tables | One ratio rarely serves both extremes well | Use a tighter ratio (1.125) for data, wider (1.25–1.333) for marketing contexts |
+| Letter-spacing added to running body text | Loosens the type and slows reading | Keep body tracking at 0; add spacing only to uppercase labels |
+| Regular-weight white text on a dark background | Halation makes it look thin and frail | Step up one weight (medium/semibold) for light-on-dark text |
+| Monospace as a default UI font, or monospace + uppercase | Hard to scan, reads as "unstyled" | Scope monospace to code/IDs/numeric data only |

--- a/skills/modular-scale-typography/SKILL.md
+++ b/skills/modular-scale-typography/SKILL.md
@@ -146,8 +146,8 @@ Size and ratio set the structure; these details determine whether the type actua
 
 ### Letter Spacing
 - **Body and default text:** keep letter-spacing at `0`. Resist adding tracking to running text — it slows reading and makes the type feel loose and uncommitted. When in doubt, use none.
-- **Uppercase and small labels:** uppercase is the one place tracking helps, because capitals are visually tighter. Add it sparingly and **cap it at `0.0125rem`** — reach for that maximum only when the label genuinely needs more air, not by default.
-- The pattern: **zero on lowercase body, at most a hair (`≤ 0.0125rem`) on uppercase labels when airiness is needed** — never a blanket value across the whole UI. Over-tracking reads as dated, not premium.
+- **Uppercase and small labels:** uppercase is the one place tracking helps, because capitals are visually tighter. Add it sparingly and **cap it at `0.04em`** — reach for that maximum only when the label genuinely needs more air, not by default.
+- The pattern: **zero on lowercase body, at most a hair (`≤ 0.04em`) on uppercase labels when airiness is needed** — never a blanket value across the whole UI. Over-tracking reads as dated, not premium.
 
 ### Weight on Dark Backgrounds
 White (or light) text on a dark background appears optically **thinner** than the same weight on a light background — a halation effect where the bright type bleeds into the dark field. Compensate by stepping up one weight: if a regular (400) weight works for body on light, use a **medium or semibold cut for the equivalent text on dark**. This keeps perceived weight consistent across light and dark modes instead of dark-mode text looking frail.
@@ -170,7 +170,7 @@ A successful heading scale uses more than just font size to distinguish levels. 
 ### Tools for Differentiation
 If headings only differ by small increments of size, they become hard to distinguish at a glance. Use these tools to create a more meaningful scale:
 - **Capitalization:** Use uppercase (`text-transform: uppercase`) for small, lower-level headings (H4–H5) to give them visual weight without needing large sizes.
-- **Letter Spacing:** When using uppercase or bold headings, add at most a hair of `letter-spacing` (`≤ 0.0125rem`) — and only when the heading genuinely needs the air. Keep it subtle; over-tracking reads as dated, not premium.
+- **Letter Spacing:** When using uppercase or bold headings, add at most a hair of `letter-spacing` (`≤ 0.04em`) — and only when the heading genuinely needs the air. Keep it subtle; over-tracking reads as dated, not premium.
 - **Color:** Use your brand primary colour or a slightly muted grey for secondary headings to differentiate them from the main black/dark-grey text.
 - **Style:** Use italics or subtle underlines for supplementary or metadata-style headings.
 
@@ -207,7 +207,7 @@ Use specific typographic roles to provide context and guide the user through the
 
 | Role | Visual Treatment | Purpose |
 |---|---|---|
-| **Pre-title (Eyebrow)** | Small (12–13px), often all-caps, subtle letter-spacing (`≤ 0.0125rem`), muted colour | Provides context or category without distracting from the main heading |
+| **Pre-title (Eyebrow)** | Small (12–13px), often all-caps, subtle letter-spacing (`≤ 0.04em`), muted colour | Provides context or category without distracting from the main heading |
 | **Heading** | Large, bold, modular scale step +3 to +5 | The primary hook or subject |
 | **Ingress (Lead text)** | Larger than body (step +1), slightly bolder or higher line-height | Summarises the core value; bridging the heading and the body copy |
 | **Body** | Base size (16px), regular weight, comfortable line-height (1.5) | The primary reading experience |
@@ -236,7 +236,7 @@ Never shrink the scale from the bottom. Body text at 16px is already a floor —
 - [ ] Is 14px used only for secondary/metadata text, never for body copy?
 - [ ] Is nothing below 14px used anywhere in the UI?
 - [ ] Is sub-16px text kept to a small fraction (~1%) of the page, not the default?
-- [ ] Is body letter-spacing 0, with uppercase-label tracking capped at `0.0125rem` and used only when air is needed?
+- [ ] Is body letter-spacing 0, with uppercase-label tracking capped at `0.04em` and used only when air is needed?
 - [ ] Does light-on-dark text use a slightly heavier cut to compensate for halation?
 - [ ] Is monospace scoped to technical content, never used as a default or with uppercase?
 - [ ] Is there at least 3–4 distinct steps between body text and the largest heading?
@@ -257,6 +257,6 @@ Never shrink the scale from the bottom. Body text at 16px is already a floor —
 | Arbitrary sizes with no relationship (13, 18, 27, 36px) | No underlying logic — hierarchy feels accidental | Regenerate from a single base and ratio |
 | Pixel values hard-coded in components instead of tokens | Scale changes require hunting through every file | Define once as CSS custom properties or design tokens |
 | Same scale used for display headings and dense data tables | One ratio rarely serves both extremes well | Use a tighter ratio (1.125) for data, wider (1.25–1.333) for marketing contexts |
-| Letter-spacing added to running body text | Loosens the type and slows reading | Keep body tracking at 0; add at most `0.0125rem` to uppercase labels when air is needed |
+| Letter-spacing added to running body text | Loosens the type and slows reading | Keep body tracking at 0; add at most `0.04em` to uppercase labels when air is needed |
 | Regular-weight white text on a dark background | Halation makes it look thin and frail | Step up one weight (medium/semibold) for light-on-dark text |
 | Monospace as a default UI font, or monospace + uppercase | Hard to scan, reads as "unstyled" | Scope monospace to code/IDs/numeric data only |

--- a/skills/modular-scale-typography/SKILL.md
+++ b/skills/modular-scale-typography/SKILL.md
@@ -138,7 +138,12 @@ With a modular scale, every size step carries the same visual weight of change. 
 
 In the modular scale, this means the base (`step 0`) should be 16px, and negative steps (step -1, step -2) should be used only for genuinely secondary content — never for body copy or primary labels.
 
-**The 1% heuristic.** Sub-16px text should be the rare exception, not a habit. As a rule of thumb, keep **at most ~1% of the text on a page below 16px**, and never below 14px. If a layout pushes large amounts of text down to 13–14px to fit, the problem is layout density, not type size — reduce what is shown rather than shrinking the type.
+**The 1% heuristic.** Sub-16px text should be the rare exception, not a habit — as a memorable target, **under ~1% of a page's text below 16px** (and never below 14px). Since nobody counts characters, apply it as a checkable role test instead:
+
+- **Allowed below 16px** — a short, fixed whitelist of genuinely secondary roles: timestamps, captions, table metadata, input helper text, legal fine print, badge labels. These are glanced at, not read.
+- **Never below 16px** — body copy, primary labels, list item titles, anything the user actually reads to do the task.
+
+The practical check: **scan one screen and count the distinct text roles rendered below 16px.** Two or three (from the whitelist) is healthy. If five or more different things are sub-16px — or if any of them is real reading content — you have over-shrunk. That is a sign of layout density, not a type problem: reduce what is shown rather than shrinking the type to fit.
 
 ## Type Rendering Details
 
@@ -235,7 +240,7 @@ Never shrink the scale from the bottom. Body text at 16px is already a floor —
 - [ ] Is the base size 16px or larger?
 - [ ] Is 14px used only for secondary/metadata text, never for body copy?
 - [ ] Is nothing below 14px used anywhere in the UI?
-- [ ] Is sub-16px text kept to a small fraction (~1%) of the page, not the default?
+- [ ] Counting distinct sub-16px text roles on a screen, are there only a few (≤3) and all from the secondary whitelist — never reading content?
 - [ ] Is body letter-spacing 0, with uppercase-label tracking capped at `0.04em` and used only when air is needed?
 - [ ] Does light-on-dark text use a slightly heavier cut to compensate for halation?
 - [ ] Is monospace scoped to technical content, never used as a default or with uppercase?

--- a/skills/modular-scale-typography/SKILL.md
+++ b/skills/modular-scale-typography/SKILL.md
@@ -145,9 +145,9 @@ In the modular scale, this means the base (`step 0`) should be 16px, and negativ
 Size and ratio set the structure; these details determine whether the type actually reads well on screen.
 
 ### Letter Spacing
-- **Body and default text:** keep letter-spacing at or near `0`. Resist adding tracking to running text — it slows reading and makes the type feel loose and uncommitted. When in doubt, use less.
-- **Uppercase and small labels:** uppercase is the one place to *add* tracking (`0.03em`–`0.08em`), because capitals are visually tighter and need air to stay legible at small sizes.
-- The pattern: **less letter-spacing on lowercase body, more on uppercase labels** — never a blanket value across the whole UI.
+- **Body and default text:** keep letter-spacing at `0`. Resist adding tracking to running text — it slows reading and makes the type feel loose and uncommitted. When in doubt, use none.
+- **Uppercase and small labels:** uppercase is the one place tracking helps, because capitals are visually tighter. Add it sparingly and **cap it at `0.0125rem`** — reach for that maximum only when the label genuinely needs more air, not by default.
+- The pattern: **zero on lowercase body, at most a hair (`≤ 0.0125rem`) on uppercase labels when airiness is needed** — never a blanket value across the whole UI. Over-tracking reads as dated, not premium.
 
 ### Weight on Dark Backgrounds
 White (or light) text on a dark background appears optically **thinner** than the same weight on a light background — a halation effect where the bright type bleeds into the dark field. Compensate by stepping up one weight: if a regular (400) weight works for body on light, use a **medium or semibold cut for the equivalent text on dark**. This keeps perceived weight consistent across light and dark modes instead of dark-mode text looking frail.
@@ -170,7 +170,7 @@ A successful heading scale uses more than just font size to distinguish levels. 
 ### Tools for Differentiation
 If headings only differ by small increments of size, they become hard to distinguish at a glance. Use these tools to create a more meaningful scale:
 - **Capitalization:** Use uppercase (`text-transform: uppercase`) for small, lower-level headings (H4–H5) to give them visual weight without needing large sizes.
-- **Letter Spacing:** When using uppercase or bold headings, add a small amount of `letter-spacing` (e.g., `0.05em`) to improve legibility and provide a "premium" feel.
+- **Letter Spacing:** When using uppercase or bold headings, add at most a hair of `letter-spacing` (`≤ 0.0125rem`) — and only when the heading genuinely needs the air. Keep it subtle; over-tracking reads as dated, not premium.
 - **Color:** Use your brand primary colour or a slightly muted grey for secondary headings to differentiate them from the main black/dark-grey text.
 - **Style:** Use italics or subtle underlines for supplementary or metadata-style headings.
 
@@ -207,7 +207,7 @@ Use specific typographic roles to provide context and guide the user through the
 
 | Role | Visual Treatment | Purpose |
 |---|---|---|
-| **Pre-title (Eyebrow)** | Small (12–13px), often all-caps, high letter-spacing, muted colour | Provides context or category without distracting from the main heading |
+| **Pre-title (Eyebrow)** | Small (12–13px), often all-caps, subtle letter-spacing (`≤ 0.0125rem`), muted colour | Provides context or category without distracting from the main heading |
 | **Heading** | Large, bold, modular scale step +3 to +5 | The primary hook or subject |
 | **Ingress (Lead text)** | Larger than body (step +1), slightly bolder or higher line-height | Summarises the core value; bridging the heading and the body copy |
 | **Body** | Base size (16px), regular weight, comfortable line-height (1.5) | The primary reading experience |
@@ -236,7 +236,7 @@ Never shrink the scale from the bottom. Body text at 16px is already a floor —
 - [ ] Is 14px used only for secondary/metadata text, never for body copy?
 - [ ] Is nothing below 14px used anywhere in the UI?
 - [ ] Is sub-16px text kept to a small fraction (~1%) of the page, not the default?
-- [ ] Is body letter-spacing at/near 0, with extra tracking reserved for uppercase labels?
+- [ ] Is body letter-spacing 0, with uppercase-label tracking capped at `0.0125rem` and used only when air is needed?
 - [ ] Does light-on-dark text use a slightly heavier cut to compensate for halation?
 - [ ] Is monospace scoped to technical content, never used as a default or with uppercase?
 - [ ] Is there at least 3–4 distinct steps between body text and the largest heading?
@@ -257,6 +257,6 @@ Never shrink the scale from the bottom. Body text at 16px is already a floor —
 | Arbitrary sizes with no relationship (13, 18, 27, 36px) | No underlying logic — hierarchy feels accidental | Regenerate from a single base and ratio |
 | Pixel values hard-coded in components instead of tokens | Scale changes require hunting through every file | Define once as CSS custom properties or design tokens |
 | Same scale used for display headings and dense data tables | One ratio rarely serves both extremes well | Use a tighter ratio (1.125) for data, wider (1.25–1.333) for marketing contexts |
-| Letter-spacing added to running body text | Loosens the type and slows reading | Keep body tracking at 0; add spacing only to uppercase labels |
+| Letter-spacing added to running body text | Loosens the type and slows reading | Keep body tracking at 0; add at most `0.0125rem` to uppercase labels when air is needed |
 | Regular-weight white text on a dark background | Halation makes it look thin and frail | Step up one weight (medium/semibold) for light-on-dark text |
 | Monospace as a default UI font, or monospace + uppercase | Hard to scan, reads as "unstyled" | Scope monospace to code/IDs/numeric data only |


### PR DESCRIPTION
Incorporates the practical UI tips (from the @dembranded thread on improving Claude-native UI) into existing skills rather than adding new ones. Tips already covered by current skills were skipped; only the genuinely new nuances were added.

## modular-scale-typography
- **1% heuristic** — keep at most ~1% of page text below 16px; never below 14px.
- **Letter spacing** — tight/0 on lowercase body, extra tracking only on uppercase labels (not a blanket value).
- **Weight on dark** — light-on-dark text appears thinner (halation); step up one weight to compensate.
- **Monospace** — scope to technical content; avoid as a default UI font and avoid monospace + uppercase.
- Added matching checklist items and anti-pattern rows.

## gestalt-ui-organisation
- **Whitespace over separators** — default to spacing, not divider lines, as the grouping signal; removing lines usually means *adding* spacing back so groups don't read as cramped.

## component-family-consistency
- **Alignment on a line** — mixed text/badges/icons share one type size and centre line; status (traffic-light) indicators centred against their label.
- **Small-component restraint** — avoid nested/multi-border containers, max one icon per small component, pivot away from card-in-card-in-card designs.

All additions are documentation-only edits to existing `SKILL.md` files (new subsections, checklist items, anti-pattern rows).