### PR TITLE
Tighten prose in recently-added UI guidance sections

### DIFF
--- a/skills/component-family-consistency/SKILL.md
+++ b/skills/component-family-consistency/SKILL.md
@@ -194,19 +194,19 @@ export function Kbd({ children }: { children: ReactNode }) {
 
 ## Alignment on a Line
 
-When a single line mixes element types — a label, a badge, a status dot, a value, an icon — they must read as one aligned row, not a jumble of differently-sized pieces.
+When a line mixes element types — label, badge, status dot, value, icon — they must read as one aligned row, not a jumble of differently-sized pieces.
 
-- **Same type size on the line.** Text sitting next to a badge or chip should share the same typeface size as the surrounding text. A badge should not silently shrink or enlarge the effective text size of its row. Use `leading-none` and `align-middle` (as in the chip `BASE` above) so every element sits on a shared centre line.
-- **Centre status indicators on the line.** A traffic-light status dot (red/amber/green) must be **vertically centred against the text it annotates**, not sitting on the baseline or floating high. Align it to the cap-height centre of the adjacent label.
-- **One baseline, one rhythm.** Mixed badges + text + icons on a row should align to a single optical centre line. If elements jump up and down, the row reads as broken even when each piece is individually fine.
+- **Same type size on the line.** Text next to a badge or chip shares the surrounding typeface size; a badge must not silently shrink or enlarge its row. Use `leading-none` and `align-middle` (as in the chip `BASE` above) so every element sits on a shared centre line.
+- **Centre status indicators.** A traffic-light dot (red/amber/green) is **vertically centred against the text it annotates** — aligned to the label's cap-height centre, not the baseline.
+- **One optical centre line.** If badges, text, and icons jump up and down, the row reads as broken even when each piece is fine alone.
 
 ## Small Component Restraint
 
 The smaller the component, the less it can carry. Restraint that looks plain at large sizes is what keeps small components legible.
 
-- **Avoid multi-border / boxed-in containers.** In small components, do not stack multiple bordered layers (a bordered chip inside a bordered cell inside a bordered card). Each border adds visual weight that a small element cannot absorb. Prefer a single border, or none — use background fill or spacing instead. This is the small-scale companion to the 2-Step border rule.
-- **Don't over-complicate with multiple icons.** A small component should carry **at most one icon**. Two or three icons crammed into a pill, badge, or list row create clutter and ambiguity about which icon is the actionable one. If you need more, the component has outgrown its size — promote it to a larger pattern.
-- **If you're about to build a multi-card-container design, pivot.** Nesting cards inside cards inside containers (card-in-card-in-card) signals that grouping is being solved with boxes instead of spacing and hierarchy. Before committing, step back: flatten the nesting, use whitespace and headings to group (see [[gestalt-ui-organisation]]), and reserve the card metaphor for the outermost meaningful container only.
+- **Avoid multi-border / boxed-in containers.** Don't stack bordered layers (a bordered chip inside a bordered cell inside a bordered card) — a small element can't absorb the weight. Prefer one border or none; use fill or spacing instead. The small-scale companion to the 2-Step border rule.
+- **At most one icon.** Two or three icons in a pill, badge, or row create clutter and ambiguity about which is actionable. If you need more, the component has outgrown its size — promote it to a larger pattern.
+- **Multi-card-container design → pivot.** Card-in-card-in-card nesting solves grouping with boxes instead of spacing and hierarchy. Flatten it, group with whitespace and headings (see [[gestalt-ui-organisation]]), and keep the card metaphor for the outermost meaningful container only.
 
 If the brand uses gradients, apply them consistently:
 

--- a/skills/gestalt-ui-organisation/SKILL.md
+++ b/skills/gestalt-ui-organisation/SKILL.md
@@ -59,9 +59,9 @@ Elements that are close together are perceived as a group.
 **Example:** A toolbar with `[Cut] [Copy] [Paste]` grouped tightly, then a wider gap before `[Undo] [Redo]`, communicates two distinct command groups without any visual divider.
 
 #### Prefer whitespace over separator lines
-Default to **whitespace, not divider lines**, as the grouping indicator. Most separators in a UI are doing work that spacing could do better — they add visual noise and a "boxed-in" feel without adding information. When reviewing, remove the majority of line separators and let proximity carry the grouping.
+Default to **whitespace, not divider lines**, for grouping. Most separators do work that spacing does better — they add noise and a "boxed-in" feel without adding information. Remove the majority and let proximity carry the grouping.
 
-One caveat: a line occupies almost no space, so removing it often leaves groups too close together. **Removing separators usually means adding spacing** — budget for the extra whitespace (and occasionally a subtle background shift or heading) rather than just deleting the line and leaving the layout cramped.
+Caveat: a line takes almost no space, so removing it leaves groups too close. **Removing separators usually means adding spacing** — budget the whitespace (occasionally a subtle background or heading) rather than just deleting the line and leaving the layout cramped.
 
 ### 2. Similarity
 Elements that look alike are perceived as related.

--- a/skills/modular-scale-typography/SKILL.md
+++ b/skills/modular-scale-typography/SKILL.md
@@ -138,27 +138,27 @@ With a modular scale, every size step carries the same visual weight of change. 
 
 In the modular scale, this means the base (`step 0`) should be 16px, and negative steps (step -1, step -2) should be used only for genuinely secondary content — never for body copy or primary labels.
 
-**The 1% heuristic.** Sub-16px text should be the rare exception, not a habit — as a memorable target, **under ~1% of a page's text below 16px** (and never below 14px). Since nobody counts characters, apply it as a checkable role test instead:
+**The 1% heuristic.** Sub-16px text is the rare exception (target: under ~1% of a page, never below 14px). Nobody counts characters, so apply it as a role test:
 
-- **Allowed below 16px** — a short, fixed whitelist of genuinely secondary roles: timestamps, captions, table metadata, input helper text, legal fine print, badge labels. These are glanced at, not read.
-- **Never below 16px** — body copy, primary labels, list item titles, anything the user actually reads to do the task.
+- **May go below 16px** — a fixed whitelist of glanced-at roles: timestamps, captions, table metadata, helper text, fine print, badge labels.
+- **Never** — body copy, primary labels, list item titles, anything actually read to do the task.
 
-The practical check: **scan one screen and count the distinct text roles rendered below 16px.** Two or three (from the whitelist) is healthy. If five or more different things are sub-16px — or if any of them is real reading content — you have over-shrunk. That is a sign of layout density, not a type problem: reduce what is shown rather than shrinking the type to fit.
+Check: scan one screen, count distinct sub-16px roles. Two or three from the whitelist is healthy; five or more — or any reading content — means you've over-shrunk. That's layout density, not a type problem: cut what's shown rather than shrink the type to fit.
 
 ## Type Rendering Details
 
 Size and ratio set the structure; these details determine whether the type actually reads well on screen.
 
 ### Letter Spacing
-- **Body and default text:** keep letter-spacing at `0`. Resist adding tracking to running text — it slows reading and makes the type feel loose and uncommitted. When in doubt, use none.
-- **Uppercase and small labels:** uppercase is the one place tracking helps, because capitals are visually tighter. Add it sparingly and **cap it at `0.04em`** — reach for that maximum only when the label genuinely needs more air, not by default.
-- The pattern: **zero on lowercase body, at most a hair (`≤ 0.04em`) on uppercase labels when airiness is needed** — never a blanket value across the whole UI. Over-tracking reads as dated, not premium.
+- **Body and default text:** keep tracking at `0`. Adding it to running text slows reading and makes the type feel loose.
+- **Uppercase and small labels:** the one place tracking helps, since capitals are visually tight. Cap it at `0.04em`, and reach for that only when the label genuinely needs air.
+- Pattern: **zero on lowercase body, at most a hair (`≤ 0.04em`) on uppercase labels** — never a blanket value. Over-tracking reads as dated, not premium.
 
 ### Weight on Dark Backgrounds
-White (or light) text on a dark background appears optically **thinner** than the same weight on a light background — a halation effect where the bright type bleeds into the dark field. Compensate by stepping up one weight: if a regular (400) weight works for body on light, use a **medium or semibold cut for the equivalent text on dark**. This keeps perceived weight consistent across light and dark modes instead of dark-mode text looking frail.
+Light text on dark appears optically **thinner** — a halation effect where bright type bleeds into the dark field. Step up one weight to compensate: where regular (400) works on light, use **medium or semibold for the equivalent text on dark**. This keeps perceived weight consistent across modes instead of dark-mode text looking frail.
 
 ### Monospace
-Monospace is for technical content where character alignment matters — code, IDs, numeric tables, diffs. **Do not use it as a default UI typeface, and avoid monospace + uppercase together** (the even widths plus tall capitals are hard to scan). Keep monospace scoped to the content that genuinely benefits from fixed-width rendering.
+Monospace is for technical content where character alignment matters — code, IDs, numeric tables, diffs. **Don't use it as a default UI typeface, and avoid monospace + uppercase** (even widths plus tall capitals are hard to scan).
 
 ## Type Scale by Page Context
 


### PR DESCRIPTION
Follow-up to #28. A density pass over the sections that PR added — same rules and rationale, ~30% less prose.

The reasoning (the *why*) is kept, since it's what lets the guidance generalize beyond the enumerated cases. What's cut is padding: restated clauses, hedging, and over-explanation.

**Sections tightened:**
- `modular-scale-typography` — 1% heuristic, Letter Spacing, Weight on Dark, Monospace
- `gestalt-ui-organisation` — Prefer whitespace over separator lines
- `component-family-consistency` — Alignment on a Line, Small Component Restraint

**Word counts (whole file):**
- modular-scale-typography: 2559 → 2443
- component-family-consistency: 1857 → 1765
- gestalt-ui-organisation: 889 → 869

No rule, number, checklist item, or anti-pattern changed — only the prose density of the new sections.