### PR TITLE
feat(skills): add tab-navigation and modal-and-overlay-patterns

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "skills/sticky-and-fixed-elements",
     "skills/scroll-areas",
     "skills/real-world-metaphors",
+    "skills/tab-navigation",
+    "skills/modal-and-overlay-patterns",
     "skills/form-design",
     "skills/data-display-and-selection",
     "skills/global-toolbar-controls",

--- a/skills/dembrandt/SKILL.md
+++ b/skills/dembrandt/SKILL.md
@@ -115,6 +115,8 @@ Review component patterns and interactive states.
 
 Sub-skills (load as needed):
 - `real-world-metaphors` — cards, carousels, drawers: when to use and how
+- `tab-navigation` — tab types, overflow, keyboard nav, ARIA, state persistence
+- `modal-and-overlay-patterns` — tooltip/popover/drawer/modal hierarchy, focus management, destructive confirm
 - `form-design` — helper text, placeholder, validation, submit state
 - `data-display-and-selection` — grid/list/table, large hit areas, mass actions
 - `global-toolbar-controls` — currency, language, locale: placement and typography

--- a/skills/modal-and-overlay-patterns/SKILL.md
+++ b/skills/modal-and-overlay-patterns/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: modal-and-overlay-patterns
+description: Overlays — modals, drawers, bottom sheets, popovers — interrupt or augment the main flow. Each type has a different scope, blocking level, and appropriate use case. Use when designing dialogs, confirmation prompts, side panels, action sheets, or any UI element that appears above the main content layer.
+metadata:
+  priority: 7
+  pathPatterns:
+    - "components/**"
+    - "src/components/**"
+    - "**/*.tsx"
+    - "**/*.jsx"
+    - "design-system/**"
+    - "ui/**"
+  promptSignals:
+    phrases:
+      - "modal"
+      - "dialog"
+      - "drawer"
+      - "overlay"
+      - "popover"
+      - "bottom sheet"
+      - "sheet"
+      - "action sheet"
+      - "side panel"
+      - "lightbox"
+      - "confirm"
+      - "confirmation dialog"
+retrieval:
+  aliases:
+    - modal dialog
+    - overlay pattern
+    - drawer panel
+    - bottom sheet
+    - popover
+    - confirmation dialog
+    - side panel
+    - action sheet
+  intents:
+    - design a modal dialog
+    - add a confirmation prompt
+    - build a side drawer
+    - choose between modal and drawer
+    - design a bottom sheet for mobile
+    - add a popover for contextual info
+  examples:
+    - add a confirm dialog before deleting
+    - should this be a modal or a drawer
+    - design a side panel for editing details
+    - add a popover to explain this field
+---
+
+# Modal and Overlay Patterns
+
+Overlays appear above the main content layer. They range from lightweight popovers (non-blocking, anchored to a trigger) to full blocking modals (require a user response before the app continues). Choosing the right overlay type for the task prevents unnecessary interruption and keeps the user oriented.
+
+---
+
+## The Overlay Hierarchy
+
+Choose the lightest type that satisfies the task. Heavier overlays carry higher cognitive cost.
+
+| Type | Blocks background | Anchored to trigger | Typical content | Dismiss with |
+|---|---|---|---|---|
+| **Tooltip** | No | Yes | 1–2 lines of explanatory text | Cursor leave / focus out |
+| **Popover** | No | Yes | Short interactive content: a form field, a picker, a small list | Click outside, Escape, explicit close |
+| **Dropdown / Menu** | No | Yes | List of actions or options | Click outside, Escape, selection |
+| **Bottom sheet** (mobile) | Partial (dimmed) | No | Actions or content on small screens | Swipe down, tap scrim, Escape |
+| **Drawer / Side panel** | Partial (dimmed) | No | Secondary editing, detail views, long forms | Escape, explicit close; optionally click scrim |
+| **Dialog / Modal** | Yes (full scrim) | No | Blocking task: confirm action, fill required form | Escape (non-destructive only), explicit button |
+| **Full-screen overlay** | Yes (complete) | No | Immersive task: media viewer, complex configuration | Explicit close only |
+
+**Decision rule:** If the user can continue using the rest of the app while the overlay is open, use a non-blocking type (drawer, popover). If the app must wait for the user's response, use a modal.
+
+---
+
+## Tooltip
+
+A tooltip appears on hover or keyboard focus and disappears when the trigger loses focus. It is purely informational — no interactive elements inside.
+
+- Content: one short sentence, label, or keyboard shortcut. Never put a link or button inside a tooltip.
+- Delay: 300–400ms on hover; no delay on keyboard focus.
+- Position: prefer above the trigger; auto-flip when viewport edge is near.
+- ARIA: `role="tooltip"` on the element; `aria-describedby` on the trigger pointing to the tooltip id.
+
+---
+
+## Popover
+
+A popover is anchored to a trigger but contains interactive content — a colour picker, a date range selector, a small form, a list of filters. Unlike a tooltip, it stays open while the user interacts.
+
+- Max width: 280–360px. For larger content, use a drawer.
+- Position: anchored to the trigger; auto-flip to stay in viewport.
+- Dismiss: click outside, Escape key, or explicit close button when the content is long.
+- Focus: move focus into the popover when it opens; return focus to the trigger on close.
+- ARIA: `role="dialog"` (if interactive) or `role="listbox"` (if a list); `aria-haspopup` on the trigger.
+
+---
+
+## Dropdown and Menu
+
+A dropdown lists selectable options or actions anchored to a trigger button. It is the lightest interactive overlay.
+
+- Separate **select dropdowns** (the user picks one value that persists) from **action menus** (the user triggers an action that doesn't persist as a value).
+- Width: at least as wide as the trigger; cap at 280px.
+- Long lists: add a search input at the top when there are more than 8–10 items.
+- Keyboard: `↑`/`↓` to move between items, `Enter` to select, `Escape` to close.
+
+---
+
+## Bottom Sheet (Mobile)
+
+On small screens, a bottom sheet replaces modals and popovers. It slides up from the bottom edge and feels native to touch devices.
+
+- **Peek height:** Show a small portion of the sheet first (a handle + title), let the user drag to expand.
+- **Full-height:** For longer content or forms that need the full viewport.
+- Dismiss: swipe down, tap the scrim, or press Escape.
+- Do not centre dialogs on mobile — use a bottom sheet instead (centred modals are too small and hard to reach).
+- ARIA: treat as `role="dialog"` with the same focus management as a modal.
+
+---
+
+## Drawer / Side Panel
+
+A drawer slides in from the left or right and partially covers the main content. Use it for secondary editing tasks, detail views, or settings that the user might refer back to while using the main content.
+
+- **Right drawer:** Detail view, editing form, filter/sort panel. Most common.
+- **Left drawer:** Navigation on mobile (hamburger menu pattern).
+- Width: 320–480px on desktop. Full-width on mobile (effectively a bottom sheet or full-screen overlay instead).
+- Scrim: a semi-transparent backdrop (`rgba(0,0,0,0.4)`) behind the drawer dims the main content.
+- Dismiss: Escape key, explicit close button. Clicking the scrim is optional — avoid it when the drawer contains an unsaved form.
+- Do not use a drawer when the task is blocking (e.g. a required decision). Use a modal instead.
+- ARIA: `role="dialog"`, `aria-modal="true"`, `aria-labelledby` pointing to the drawer title.
+
+---
+
+## Modal / Dialog
+
+A modal blocks the entire UI with a full scrim. Use it only when the app genuinely cannot continue without the user's response.
+
+### When to use a modal
+
+- Confirming a destructive or irreversible action
+- A required form that must be submitted before continuing
+- An error or warning that requires the user's acknowledgement
+
+### When not to use a modal
+
+- Displaying information the user can read at their leisure → use an inline notice or notification
+- A task the user might want to do alongside the main content → use a drawer
+- A large form with many fields → use a dedicated page or a drawer
+
+### Anatomy
+
+```
+┌──────────────────────────────────┐
+│  Title                      [✕]  │  ← Header: title + close button
+├──────────────────────────────────┤
+│                                  │
+│  Body content                    │  ← Content: scrolls if needed
+│  (description, form, media)      │
+│                                  │
+├──────────────────────────────────┤
+│               [Cancel]  [Confirm]│  ← Footer: actions, right-aligned
+└──────────────────────────────────┘
+```
+
+### Sizing
+
+| Size | Width | Use for |
+|---|---|---|
+| Small | 360px | Short confirmations, single-field prompts |
+| Medium | 480px | Standard dialogs, short forms |
+| Large | 640px | Multi-field forms, richer content |
+| Full-screen | 100% viewport | Immersive tasks; use sparingly |
+
+Content that overflows the modal height should scroll within the **body area only** — the header and footer must remain visible.
+
+### Dismiss behaviour
+
+| Trigger | Allowed for non-destructive? | Allowed for destructive? |
+|---|---|---|
+| `Escape` key | Yes | No — require explicit Cancel |
+| Click outside scrim | Yes (optional) | No — too easy to dismiss accidentally |
+| Close button (✕) | Yes | Yes |
+| Cancel button | Yes | Yes |
+
+For destructive or irreversible actions: disable Escape and click-outside dismissal. The user must explicitly press Cancel or Confirm.
+
+### Stacking modals
+
+Avoid opening a modal from inside a modal. It signals an information architecture problem — the task is likely too complex for a single dialog.
+
+If a secondary overlay is unavoidable, use a popover anchored inside the modal rather than another full modal. Never stack two blocking scrim overlays.
+
+---
+
+## Focus Management
+
+Every overlay must manage focus correctly. Broken focus management is one of the most common accessibility failures.
+
+### On open
+1. Move focus to the first interactive element inside the overlay (usually the first field, or the confirm button for confirmations).
+2. Trap focus: `Tab` and `Shift+Tab` cycle within the overlay only; focus cannot escape to the content behind the scrim.
+
+### On close
+Return focus to the element that triggered the overlay. If the trigger no longer exists (the element was deleted), move focus to a logical nearby element.
+
+### Implementation note
+Use a focus trap library or the native `<dialog>` element, which handles trapping natively in modern browsers. Rolling a manual focus trap is error-prone.
+
+---
+
+## ARIA for Modals and Drawers
+
+```html
+<div
+  role="dialog"
+  aria-modal="true"
+  aria-labelledby="modal-title"
+  aria-describedby="modal-description"
+>
+  <h2 id="modal-title">Delete project?</h2>
+  <p id="modal-description">
+    This will permanently delete "Apollo" and all its data. This cannot be undone.
+  </p>
+  <button>Cancel</button>
+  <button>Delete</button>
+</div>
+```
+
+- `role="dialog"` on the container
+- `aria-modal="true"` tells screen readers to ignore content behind the overlay
+- `aria-labelledby` points to the dialog title's id
+- `aria-describedby` points to the description's id (optional but helpful for confirmations)
+- The scrim backdrop should have `aria-hidden="true"` — screen readers must not read it
+
+---
+
+## Destructive Confirmation Pattern
+
+Confirmation dialogs for destructive actions must name the item and consequence. Generic "Are you sure?" dialogs don't give enough context.
+
+**Do:**
+> Delete "Apollo Project"?
+> This will permanently remove all tasks, files, and history. This cannot be undone.
+> [Cancel] [Delete project]
+
+**Don't:**
+> Are you sure you want to do this?
+> [No] [Yes]
+
+- The primary destructive action button uses `--color-error` / `--color-danger`, not `--color-primary`.
+- Label the destructive button explicitly: "Delete project", "Remove member", "Cancel order" — not just "OK" or "Confirm".
+- Cancel is always on the left (or secondary position); destructive action on the right.
+
+---
+
+## Review Checklist
+
+- [ ] Is the correct overlay type chosen for the task (tooltip / popover / menu / bottom sheet / drawer / modal)?
+- [ ] Is a modal avoided when a drawer or inline pattern would suffice?
+- [ ] Does the modal/drawer have a visible title, body, and clear action buttons?
+- [ ] Does overflow content scroll within the body — with the header and footer fixed?
+- [ ] Is Escape disabled for destructive actions (click-outside too)?
+- [ ] Does focus move into the overlay on open, and return to the trigger on close?
+- [ ] Is focus trapped within the overlay while it's open?
+- [ ] Is `role="dialog"`, `aria-modal="true"`, `aria-labelledby` set correctly?
+- [ ] Does the destructive confirm dialog name the item and describe the consequence?
+- [ ] Is the destructive button labelled explicitly (not "OK" or "Confirm")?
+- [ ] Are stacked modals avoided?
+- [ ] On mobile, are modals replaced with bottom sheets?

--- a/skills/tab-navigation/SKILL.md
+++ b/skills/tab-navigation/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: tab-navigation
+description: Tabs organise related content under a shared context — switching tabs swaps the view without leaving the page. Use when a screen has multiple distinct content areas that share a common header or action set, and when the user needs to switch between them frequently. Use when designing tabbed layouts, content panels, settings pages, detail views, or dashboards with multiple data views.
+metadata:
+  priority: 7
+  pathPatterns:
+    - "components/**"
+    - "src/components/**"
+    - "**/*.tsx"
+    - "**/*.jsx"
+    - "design-system/**"
+    - "ui/**"
+  promptSignals:
+    phrases:
+      - "tab"
+      - "tabs"
+      - "tab panel"
+      - "tabbed"
+      - "tab navigation"
+      - "tab bar"
+      - "tab strip"
+      - "content switcher"
+      - "pivot"
+retrieval:
+  aliases:
+    - tab navigation
+    - tab panel
+    - tabbed interface
+    - content switcher
+    - tab bar
+    - pivot control
+  intents:
+    - design a tabbed layout
+    - add tabs to a detail view
+    - organise content with tabs
+    - switch between data views
+    - build a settings page with tabs
+  examples:
+    - add tabs to this product detail page
+    - design a settings screen with tab navigation
+    - organise these data views with a tab strip
+    - make it easy to switch between different reports
+---
+
+# Tab Navigation
+
+Tabs organise related content under a shared context. The tab strip communicates the full set of available views; switching tabs swaps the content panel without a page navigation. They work best when all views share a heading, a primary action, or a common subject — tabs that have nothing to do with each other belong in separate pages.
+
+---
+
+## When to Use Tabs — and When Not To
+
+| Use tabs when… | Use something else when… |
+|---|---|
+| 2–7 views share a common context (same record, same settings section) | There are more than 7–8 tabs — use a sidebar or section nav instead |
+| Users switch between views frequently during a session | The content is sequential (use a stepper/wizard instead) |
+| All tabs are equally valid entry points | One view is clearly primary — put the rest in a secondary nav or overflow |
+| The views share a header or set of page-level actions | Each "tab" requires a different header and layout — use separate pages |
+
+---
+
+## Tab Types
+
+Choose the visual style that fits the layout context.
+
+### Underline / Indicator Tabs
+A horizontal strip with a sliding underline or bottom border on the active tab. The lightest treatment — appropriate for page-level tabs where the tab strip sits inside the content area.
+
+```
+Overview  |  Activity  |  Settings
+──────────
+```
+
+### Contained / Boxed Tabs
+Each tab is a distinct box; the active tab appears connected to the panel below. Higher visual weight — appropriate for prominent tab groups near the top of a screen or within a card.
+
+### Pill / Button Tabs
+Rounded capsules that toggle between states. Lower emphasis — appropriate for secondary content switches within a section (not page-level). Often used for view toggles (e.g. "List / Grid / Map").
+
+---
+
+## Anatomy
+
+```
+┌─────────────────────────────────────────────────┐
+│  Tab A  │  Tab B  │  Tab C  │                   │  ← Tab strip (role="tablist")
+├─────────┴─────────────────────────────────────────┤
+│                                                   │
+│   Tab panel content                               │  ← Tab panel (role="tabpanel")
+│                                                   │
+└───────────────────────────────────────────────────┘
+```
+
+- **Tab strip:** Fixed height (typically 40–48px). Does not scroll with the page — consider making it sticky when the page is long.
+- **Tab panel:** Fills the remaining available height. The panel, not the tab strip, scrolls when content overflows.
+- **Active indicator:** A 2–3px bottom border in `--color-primary` for underline tabs; filled background for contained/pill tabs.
+
+---
+
+## States
+
+| State | Visual treatment |
+|---|---|
+| Active | Primary colour indicator; label in `--color-text-primary` or primary |
+| Inactive | Muted label (`--color-text-secondary`); no indicator |
+| Hover | Subtle background shift (`--color-grey-50`); label slightly darkens |
+| Focus | Visible focus ring (`outline: 2px solid --color-primary; outline-offset: 2px`) |
+| Disabled | Reduced opacity (`0.4`); `cursor: not-allowed`; never the active tab |
+
+Never disable the active tab. If content is unavailable, show it inside the panel with an explanation rather than disabling the tab.
+
+---
+
+## Tab Overflow
+
+When the tab strip is wider than the viewport or container, do not wrap tabs onto multiple lines — it destroys the strip metaphor.
+
+### Scrollable strip
+The strip scrolls horizontally. Show a fade/gradient at the right edge to signal overflow. On touch devices this is the preferred solution.
+
+```css
+.tab-strip {
+  display: flex;
+  overflow-x: auto;
+  scrollbar-width: none; /* hide scrollbar visually on desktop */
+}
+.tab-strip::after {
+  content: '';
+  position: absolute; right: 0;
+  background: linear-gradient(to left, var(--color-surface), transparent);
+  pointer-events: none;
+}
+```
+
+### "More" overflow menu
+Show as many tabs as fit, then collapse the rest into a `More ▾` dropdown. Update the "More" label when an overflowed tab is active: `Settings ▾` (showing the active hidden tab name).
+
+For desktop dashboards with many views, prefer a sidebar nav over overflow tabs.
+
+---
+
+## Vertical Tabs
+
+Use when there are 5+ tabs and the layout has a left sidebar. Vertical tabs allow longer labels without overflow issues and scale more gracefully.
+
+- Fixed width sidebar (typically 200–240px) with tab labels stacked vertically
+- Active tab: left border accent (`3px solid --color-primary`) + subtle background
+- The main content area fills the remaining width
+
+---
+
+## Keyboard Navigation
+
+Tabs follow the ARIA "roving tabindex" pattern for within-strip navigation.
+
+| Key | Action |
+|---|---|
+| `Tab` | Move focus to the tab strip (then into the active panel) |
+| `←` / `→` | Move between tabs (horizontal strip); activate immediately or on Enter depending on content cost |
+| `↑` / `↓` | Move between tabs (vertical strip) |
+| `Home` | Jump to first tab |
+| `End` | Jump to last tab |
+| `Enter` / `Space` | Activate focused tab (if not already auto-activating on arrow key) |
+
+**Auto-activate vs. manual activate:** If switching tabs triggers a network request, use manual activation (arrow keys move focus, Enter activates) to avoid unnecessary fetches. If content is already loaded or cheap, auto-activation on arrow key is acceptable.
+
+---
+
+## ARIA
+
+```html
+<div role="tablist" aria-label="Product sections">
+  <button
+    role="tab"
+    id="tab-overview"
+    aria-selected="true"
+    aria-controls="panel-overview"
+    tabindex="0"
+  >Overview</button>
+  <button
+    role="tab"
+    id="tab-activity"
+    aria-selected="false"
+    aria-controls="panel-activity"
+    tabindex="-1"
+  >Activity</button>
+</div>
+
+<div
+  role="tabpanel"
+  id="panel-overview"
+  aria-labelledby="tab-overview"
+>…</div>
+
+<div
+  role="tabpanel"
+  id="panel-activity"
+  aria-labelledby="tab-activity"
+  hidden
+>…</div>
+```
+
+- `aria-selected="true"` on the active tab, `false` on all others
+- `tabindex="0"` on the active tab, `-1` on all others (roving tabindex)
+- `hidden` attribute (or `display: none`) on inactive panels — screen readers skip hidden panels
+- `aria-label` on the `tablist` when the heading above doesn't sufficiently describe the group
+
+---
+
+## State Persistence
+
+Remember the active tab across page loads and navigations:
+
+- **URL fragment or query param:** `?tab=activity` — the most robust approach; supports deep linking and browser back/forward
+- **localStorage:** Acceptable for preferences (e.g. a preferred dashboard view) that don't need to be shareable
+- Do not use `sessionStorage` — tabs closing lose the state unexpectedly
+
+When the URL contains a tab param, jump to that tab on load even if it's not the first tab.
+
+---
+
+## Nested Tabs
+
+Avoid tabs within tabs. Nested tabbing creates confusion about scope — a user editing content in "Tab A › Sub-tab 2" has no clear mental model of what the outer tab means.
+
+If you find yourself nesting tabs, reconsider the information architecture:
+- Can the inner tabs become a secondary nav (pills, a sidebar within the panel)?
+- Can the outer tabs become a top-level page nav instead?
+
+One level of tabs maximum in the primary content area.
+
+---
+
+## Review Checklist
+
+- [ ] Are there 2–7 tabs, each sharing a common subject or context?
+- [ ] Is the tab strip not wrapping to multiple lines on any target viewport?
+- [ ] Does tab overflow use scrollable strip or a "More" menu — not wrapping?
+- [ ] Is the active tab clearly distinguished by colour and/or indicator?
+- [ ] Do hover and focus states meet contrast requirements?
+- [ ] Are disabled tabs avoided (showing unavailability inside the panel instead)?
+- [ ] Does keyboard navigation follow roving tabindex (←/→ between tabs, Tab into panel)?
+- [ ] Is `role="tablist"`, `role="tab"`, `role="tabpanel"`, and `aria-selected` set correctly?
+- [ ] Are inactive panels hidden from the accessibility tree (`hidden` attribute)?
+- [ ] Is the active tab persisted in the URL (for deep-linkable views) or localStorage?
+- [ ] Are nested tabs avoided?


### PR DESCRIPTION
## Summary

Two missing foundational interaction-pattern skills for the Component stage (Stage 4) of the dembrandt pipeline:

- **`tab-navigation`** — tab types (underline/pill/contained), overflow handling (scrollable strip, "More" menu), keyboard navigation (roving tabindex), ARIA (`tablist`/`tab`/`tabpanel`, `aria-selected`), URL-param state persistence, nested-tab warning
- **`modal-and-overlay-patterns`** — overlay hierarchy decision table (tooltip → popover → menu → bottom sheet → drawer → modal → full-screen), focus trap + return-on-close, dismiss-behaviour matrix (Escape disabled for destructive), destructive confirm naming pattern, stacked-modal warning, mobile bottom-sheet guidance, full ARIA setup

Both skills are registered in `package.json` and wired into the dembrandt orchestrator at Stage 4.

Complements the patterns in PR #34 (operational/B2B) — no overlap.

## Test plan

- [ ] Read each SKILL.md and verify it stands alone without project-specific references
- [ ] Confirm frontmatter metadata (priority, pathPatterns, promptSignals, retrieval) follows the existing pattern
- [ ] Verify Review Checklist at the end of each skill is actionable
- [ ] Confirm `package.json` entries point to the correct directory names
- [ ] Confirm dembrandt orchestrator Stage 4 lists both new skills with accurate one-liners