### PR TITLE
docs: product narrative framework for landing and marketing pages

### DIFF
--- a/skills/authentic-product-representation/SKILL.md
+++ b/skills/authentic-product-representation/SKILL.md
@@ -57,6 +57,8 @@ The fastest way to lose a visitor's trust is a product visual that is obviously 
 
 The principle is simple: **the visual is the product, not a poster of it.** Every shortcut away from that — invented data, decorative chrome, a capability shown that does not exist — is a small withdrawal from the trust account.
 
+This skill governs whether a visual is *credible*; what it has to accomplish in the page's argument comes from the product narrative framework in [[layout-paradigms-and-consistency]]. A fabricated proof point proves nothing.
+
 ---
 
 ## Design With Real Content

--- a/skills/layout-paradigms-and-consistency/SKILL.md
+++ b/skills/layout-paradigms-and-consistency/SKILL.md
@@ -129,24 +129,26 @@ Marketing and landing pages are the one paradigm where **sequence is the argumen
 
 | # | Beat | The job | Typical treatment |
 |---|---|---|---|
-| 1 | **Hook** | Stop the *right* visitor and make them want to keep reading | Large headline, generous whitespace, supporting line, product shot / video / interactive demo alongside |
-| 2 | **Problem empathy** | Prove you understand the visitor's current situation | Named pains — slow, manual, expensive, scattered, error-prone |
-| 3 | **USP** | What it does, who it's for, why it's different — in one sentence | One clear statement, given room |
-| 4 | **Value propositions** | The 3–5 differentiated benefits | Benefit phrasing, not feature nouns |
-| 5 | **Proof points** | A reason to believe each claim | Screenshot, demo, customer, statistic, case study, integration, benchmark, before/after |
-| 6 | **How it works** | Remove uncertainty about effort and mechanism | Usually three steps: connect data → it processes → you get the result |
-| 7 | **Stakes** | What it costs to do nothing | Competitors move ahead, time and money leak, errors continue |
+| 1 | **Hook** | Stop the *right* visitor and make them want to keep reading | Large headline, generous whitespace, supporting line, product shot / video / demo alongside |
+| 2 | **Problem empathy** | Prove you understand the visitor's current situation | Named pains — slow, costly, manual, unreliable, scattered, hard to source |
+| 3 | **USP** | What it is, who it's for, why it's different — in one sentence | One clear statement, given room |
+| 4 | **Value propositions** | The 3–5 differentiated benefits | Benefit phrasing, not feature or spec nouns |
+| 5 | **Proof points** | A reason to believe each claim | Whatever counts as evidence in the field — customers, figures, case studies, certifications, test data, materials, stock and delivery times, before/after |
+| 6 | **How it works** | Remove uncertainty about mechanism and effort | Three steps, in the field's own terms — order/fit/measure, connect/process/result, browse/try/return |
+| 7 | **Stakes** | What it costs to do nothing | Downtime continues, competitors move, time and money leak, the problem recurs |
 | 8 | **Call to action** | The obvious next step | A verb the visitor can picture doing |
+
+The beats are the same everywhere — B2B and B2C, software and physical goods, a global manufacturer and a local shop. What changes is their **weight and their evidence.** An industrial or spare-parts buyer wants proof, specification, fit and availability, and will read further to get it; a fashion or consumer page carries the hook in the imagery itself and reaches the CTA in far less scrolling; an internal tool's page can skip persuasion but still owes the visitor *what this is, why it exists, how to start*. Decide which beats carry the load for **this** audience before deciding what the page looks like.
 
 **The hook is a question, not a summary.** A good hero states one value and leaves the visitor thinking *"I want to see how this works."* It gets that from size and air, not decoration ([[visual-emphasis-and-hierarchy]]). If the short headline is not explanatory enough alone, add a smaller supporting line under it rather than lengthening the headline. Pair it with the product actually running — screenshot, video, or live demo, never a mockup of behaviour the product does not have ([[authentic-product-representation]]).
 
-**Value propositions are benefits, not features.** "AI dashboard" is a feature noun. "See the numbers that matter at a glance" is what the visitor gets. A line that could sit unchanged on a competitor's page is not a value proposition.
+**Value propositions are benefits, not features.** "AI dashboard" and "14 mm hardened steel" are nouns; "the numbers that matter at a glance" and "survives a season of gravel roads" are what the visitor gets. A line that could sit unchanged on a competitor's page is not a value proposition.
 
-**Every claim carries proof.** The bolder the claim, the harder the evidence. Unproven superlatives cost credibility on the claims that *are* true.
+**Every claim carries proof.** The bolder the claim, the harder the evidence. What counts as hard evidence is set by the field, not by fashion — a test report and a fitment guarantee do the work a customer logo does elsewhere. Unproven superlatives cost credibility on the claims that *are* true.
 
 **Stakes come from consequence, not pressure.** State what standing still costs. Manufactured scarcity — fake countdowns, invented "3 spots left" — spends the trust the rest of the page just built.
 
-**The CTA names the action.** "Learn more" describes nothing. "Start free", "Book a demo", "Generate your first report" tell the visitor what happens next, and hand off to a flow that delivers exactly that ([[user-flows-and-guided-paths]]).
+**The CTA names the action.** "Learn more" describes nothing. "Start free", "Check fitment", "Request a quote", "Find your size" tell the visitor what happens next, and hand off to a flow that delivers exactly that ([[user-flows-and-guided-paths]]).
 
 #### The question chain
 
@@ -156,13 +158,13 @@ The narrative works because it answers the visitor's questions in the order they
 
 This is the sharpest test here. Walk the page top to bottom and mark where each answer lands. If the visitor has to hunt or scroll back, the narrative is broken however good the sections look. Answering early is a defect too — pricing above the fold answers *"how much effort?"* to someone still asking *"what is this?"*.
 
-#### What the strongest SaaS pages share
+#### What the strongest pages share
 
-Stripe, Linear, Vercel, Notion, Figma and their peers converge on the same discipline:
+The best pages in every sector — a developer platform, a machine-tool supplier, a clothing label, a regional garage — converge on the same discipline:
 
 - **One message per viewport** — each section answers exactly one question in the chain.
-- **Less copy than feels safe**, carried by whitespace rather than paragraphs.
-- **Real product imagery and video** over abstract illustration.
+- **No more copy than the beat needs** — persuasion sections stay short and carried by whitespace, while specification and proof sections are allowed the detail a serious buyer came for.
+- **Real product imagery and video** over abstract illustration or stock photography.
 - **Benefit to proof, fast** — claims do not stack up unsupported.
 - **The CTA repeats down the page**, so the visitor can act the moment they are convinced.
 - **One visual rhythm** — section spacing, type scale, and imagery treatment repeat ([[modular-scale-typography]], [[brand-visual-language]]).
@@ -233,6 +235,7 @@ Consistency is the default, not a cage. Deviate when a screen's task genuinely d
 For a landing or marketing page:
 
 - [ ] Does the page carry all eight beats — hook, problem, USP, value props, proof, how it works, stakes, CTA?
+- [ ] Are the beats weighted for *this* audience and sector, with evidence of the kind that field actually accepts?
 - [ ] Does the hero state one value and leave the visitor wanting to see the product run?
 - [ ] Are the value propositions benefits rather than feature nouns, and does every substantial claim have proof beside it?
 - [ ] Walking top to bottom, is each question in the chain answered where it arises — none early, none requiring a scroll back?

--- a/skills/layout-paradigms-and-consistency/SKILL.md
+++ b/skills/layout-paradigms-and-consistency/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: layout-paradigms-and-consistency
-description: A layout is not a neutral container — choosing the right layout paradigm (feed, board, table, canvas, master-detail, dashboard, gallery, timeline, map, single-focus) is a design decision that shapes how content is understood. Once chosen, the same paradigm and page skeleton must be reused consistently across the application so users build one mental model. This is consistency at the macro scale, above component and token consistency. Use when deciding the overall structure of a screen, designing page templates, or reviewing whether screens across a product feel like one coherent application.
+description: A layout is not a neutral container — choosing the right layout paradigm (feed, board, table, canvas, master-detail, dashboard, gallery, timeline, map, single-focus, narrative long-scroll) is a design decision that shapes how content is understood. Landing and marketing pages get a product narrative framework — hook, problem, USP, value props, proof points, how it works, stakes, CTA — used to review whether the page carries a visitor to a decision. Once chosen, the same paradigm and page skeleton must be reused consistently across the application so users build one mental model. This is consistency at the macro scale, above component and token consistency. Use when deciding the overall structure of a screen, designing page templates, or reviewing whether screens across a product feel like one coherent application.
 metadata:
   priority: 8
   pathPatterns:
@@ -29,6 +29,14 @@ metadata:
       - "kanban"
       - "consistent layout"
       - "page structure"
+      - "landing page"
+      - "marketing page"
+      - "hero section"
+      - "product narrative"
+      - "value proposition"
+      - "proof points"
+      - "call to action"
+      - "saas landing"
   retrieval:
     aliases:
       - layout paradigm
@@ -39,18 +47,26 @@ metadata:
       - cross-page consistency
       - app-wide layout
       - macro consistency
+      - landing page structure
+      - product narrative framework
+      - marketing page review
     intents:
       - choose the right layout for this content
       - decide the overall structure of a screen
       - design reusable page templates
       - keep layouts consistent across the app
       - review whether screens feel like one product
+      - structure a landing page so it converts
+      - review whether a marketing page tells a coherent story
     examples:
       - should this be a feed, a table, or a board
       - what layout fits this kind of content
       - my detail pages are all structured differently
       - the app feels like several different products stitched together
       - design a consistent page template for these screens
+      - review my landing page
+      - our hero section is not converting
+      - does this marketing page tell the right story
 ---
 
 # Layout Paradigms and Consistency
@@ -101,10 +117,58 @@ Start from the nature of the content and the primary task, not from a default gr
 | Events ordered in time | **Timeline** | Time is the primary axis; gaps and density are meaningful | When time is just one of many equal attributes |
 | Geographic data | **Map** | Location is the primary dimension | When location is incidental to the task |
 | One object, one task, full attention | **Single-focus / Wizard** | Removes everything but the current decision | When the user needs surrounding context to decide → see [[user-flows-and-guided-paths]] |
+| Persuading a stranger who has not bought in yet | **Narrative long-scroll** | Sequence *is* the argument — each section earns the next scroll | Inside the product, where the user has already committed and wants to work |
 
 The paradigm interacts with other layout skills: it must group coherently ([[gestalt-ui-organisation]]), establish one clear emphasis ([[visual-emphasis-and-hierarchy]]), reflect the data model and naming ([[information-architecture]]), and adapt — not merely shrink — across breakpoints ([[responsive-paradigms]]). Where a real-world metaphor reinforces the paradigm (a board feels like cards on a wall), lean on it ([[real-world-metaphors]]).
 
 **A view can offer more than one paradigm.** A collection of records is legitimately a table *and* a gallery *and* a board, chosen by the user per task — see [[data-display-and-selection]]. The point is that each option is a *deliberate* fit, not an accident.
+
+### The narrative long-scroll — the product narrative framework
+
+Marketing and landing pages are the one paradigm where **sequence is the argument.** Every other paradigm arranges content the user already wants; this one earns each scroll from someone who has committed to nothing. Judge a landing page by how it carries a stranger through these beats — not by whether the sections look good in isolation.
+
+| # | Beat | The job | Typical treatment |
+|---|---|---|---|
+| 1 | **Hook** | Stop the *right* visitor and make them want to keep reading | Large headline, generous whitespace, supporting line, product shot / video / interactive demo alongside |
+| 2 | **Problem empathy** | Prove you understand the visitor's current situation | Named pains — slow, manual, expensive, scattered, error-prone |
+| 3 | **USP** | What it does, who it's for, why it's different — in one sentence | One clear statement, given room |
+| 4 | **Value propositions** | The 3–5 differentiated benefits | Benefit phrasing, not feature nouns |
+| 5 | **Proof points** | A reason to believe each claim | Screenshot, demo, customer, statistic, case study, integration, benchmark, before/after |
+| 6 | **How it works** | Remove uncertainty about effort and mechanism | Usually three steps: connect data → it processes → you get the result |
+| 7 | **Stakes** | What it costs to do nothing | Competitors move ahead, time and money leak, errors continue |
+| 8 | **Call to action** | The obvious next step | A verb the visitor can picture doing |
+
+**The hook is a question, not a summary.** A good hero states one value and leaves the visitor thinking *"I want to see how this works."* It gets that from size and air, not decoration ([[visual-emphasis-and-hierarchy]]). If the short headline is not explanatory enough alone, add a smaller supporting line under it rather than lengthening the headline. Pair it with the product actually running — screenshot, video, or live demo, never a mockup of behaviour the product does not have ([[authentic-product-representation]]).
+
+**Value propositions are benefits, not features.** "AI dashboard" is a feature noun. "See the numbers that matter at a glance" is what the visitor gets. A line that could sit unchanged on a competitor's page is not a value proposition.
+
+**Every claim carries proof.** The bolder the claim, the harder the evidence. Unproven superlatives cost credibility on the claims that *are* true.
+
+**Stakes come from consequence, not pressure.** State what standing still costs. Manufactured scarcity — fake countdowns, invented "3 spots left" — spends the trust the rest of the page just built.
+
+**The CTA names the action.** "Learn more" describes nothing. "Start free", "Book a demo", "Generate your first report" tell the visitor what happens next, and hand off to a flow that delivers exactly that ([[user-flows-and-guided-paths]]).
+
+#### The question chain
+
+The narrative works because it answers the visitor's questions in the order they arise:
+
+> What is this? → Is it for me? → Why is it better? → Can I trust it? → How does it work? → How much effort is this? → What do I do next?
+
+This is the sharpest test here. Walk the page top to bottom and mark where each answer lands. If the visitor has to hunt or scroll back, the narrative is broken however good the sections look. Answering early is a defect too — pricing above the fold answers *"how much effort?"* to someone still asking *"what is this?"*.
+
+#### What the strongest SaaS pages share
+
+Stripe, Linear, Vercel, Notion, Figma and their peers converge on the same discipline:
+
+- **One message per viewport** — each section answers exactly one question in the chain.
+- **Less copy than feels safe**, carried by whitespace rather than paragraphs.
+- **Real product imagery and video** over abstract illustration.
+- **Benefit to proof, fast** — claims do not stack up unsupported.
+- **The CTA repeats down the page**, so the visitor can act the moment they are convinced.
+- **One visual rhythm** — section spacing, type scale, and imagery treatment repeat ([[modular-scale-typography]], [[brand-visual-language]]).
+- **Restrained motion** that supports the sequence instead of competing with it ([[motion-and-storytelling]]).
+
+Density here is the deliberate *opposite* of an expert tool ([[ui-density]]). A landing page serves someone who owes you no attention; a dashboard serves someone who has already committed. Do not import habits from one into the other.
 
 ---
 
@@ -165,3 +229,11 @@ Consistency is the default, not a cage. Deviate when a screen's task genuinely d
 - [ ] Do sibling pages carry comparable feature/content weight — with over-heavy pages split and over-thin pages consolidated, rather than padded with filler (especially in expert tools)?
 - [ ] Where a screen deviates from the standard template, is there a clear task-driven reason — and is the deviation obvious rather than subtle?
 - [ ] Does the product feel like one application rather than several stitched together?
+
+For a landing or marketing page:
+
+- [ ] Does the page carry all eight beats — hook, problem, USP, value props, proof, how it works, stakes, CTA?
+- [ ] Does the hero state one value and leave the visitor wanting to see the product run?
+- [ ] Are the value propositions benefits rather than feature nouns, and does every substantial claim have proof beside it?
+- [ ] Walking top to bottom, is each question in the chain answered where it arises — none early, none requiring a scroll back?
+- [ ] Does the CTA name the action, and is urgency built from real consequence rather than manufactured scarcity?

--- a/skills/visual-emphasis-and-hierarchy/SKILL.md
+++ b/skills/visual-emphasis-and-hierarchy/SKILL.md
@@ -135,6 +135,7 @@ Users in left-to-right reading cultures scan top-left first. Position reinforces
 
 - Primary action: bottom-right of a form or dialog (natural end of the reading flow), or top-right of a page header
 - Most important content: top of the page, above the fold
+- On a landing page the hero carries one value promise, large and with air around it — for the sequence below it, see the product narrative framework in [[layout-paradigms-and-consistency]]
 - Warnings and critical status: top of the affected section, not buried at the bottom
 - Destructive actions (Delete, Remove): visually separated from constructive actions, often at the end of an action group
 


### PR DESCRIPTION
Adds a product narrative framework — hook, problem empathy, USP, value propositions, proof points, how it works, stakes, CTA — to `layout-paradigms-and-consistency` as review logic for landing and marketing pages. No new skill; still 40.

It lands there because that skill already argued layout serves the story, but its paradigm table had no marketing page in it. Narrative long-scroll is added as a paradigm: the one where sequence is the argument.

Contents: the eight beats as a table, prose rules for the ones that go wrong most (hook-as-question, benefits-not-features, claims-carry-proof, stakes-from-consequence, CTA-names-the-action), the visitor question chain, what the strongest pages share, and checklist items.

The beats hold across B2B/B2C, software and physical goods, global and local. Only weight and evidence vary — a test report does the work a customer logo does elsewhere.

Retrieval signals added for landing page, hero section, value proposition, proof points. Cross-links in from `visual-emphasis-and-hierarchy` and `authentic-product-representation`.