### PR TITLE
chore: sync with dembrandt v0.24.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dembrandt-skills",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dembrandt-skills",
-      "version": "0.3.18",
+      "version": "0.3.19",
       "devDependencies": {
         "js-yaml": "^4.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dembrandt-skills",
-  "version": "0.3.18",
+  "version": "0.3.19",
   "description": "Shareable UX and design system skills for AI agents — Gestalt, typography, modular scale, and more.",
   "scripts": {
     "test": "node test/validate-skills.mjs"


### PR DESCRIPTION
Automated sync triggered by [dembrandt v0.24.0](https://github.com/dembrandt/dembrandt/releases/tag/v0.24.0).

- Bumped `dembrandt-skills` patch version
- Updated CLI version references in skill files

**⚠ Manual check required before merging**
This automation only updates version numbers. If this release added or changed CLI flags, update `skills/extract-design/SKILL.md` manually:
- Flags reference table
- Anti-Bot section if behavior changed

See full checklist: [dembrandt/CLAUDE.md](https://github.com/dembrandt/dembrandt/blob/main/CLAUDE.md)