### PR TITLE
chore: align dembrandt engine pins + harden CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   validate-skills:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ Works with Claude Code and any agent harness that supports the Open Agent Skills
 
 | Skill | What it covers |
 |---|---|
-| `extract-design` | Extract real design tokens from any live website via Dembrandt CLI or MCP (requires dembrandt ≥ 0.12.10) |
-| `generate-ui-from-brand` | URL or DESIGN.md to tokens to decisions to UI spec (requires dembrandt ≥ 0.12.10) |
+| `extract-design` | Extract real design tokens from any live website via Dembrandt CLI or MCP (requires dembrandt ≥ 0.23.1) |
+| `generate-ui-from-brand` | URL or DESIGN.md to tokens to decisions to UI spec (requires dembrandt ≥ 0.23.1) |
 | `dembrandt` | Full 6-stage UX orchestrator: brand, tokens, layout, components, polish, a11y gate |
 
 ## Ecosystem

--- a/skills/generate-ui-from-brand/SKILL.md
+++ b/skills/generate-ui-from-brand/SKILL.md
@@ -3,7 +3,7 @@ name: generate-ui-from-brand
 description: Pipeline skill — turns a URL or DESIGN.md into a concrete UI structure with decisions already made. Extracts live design tokens, normalizes them into a semantic system, applies UX principles, and outputs an actionable UI spec. Use when building UI for an existing brand from scratch, auditing a design system, or refactoring visual inconsistency.
 metadata:
   priority: 9
-  requires: "dembrandt"
+  requires: "dembrandt>=0.23.1"
   docs:
     - "https://dembrandt.com"
     - "https://www.npmjs.com/package/dembrandt"


### PR DESCRIPTION
- generate-ui-from-brand requires dembrandt>=0.23.1 (was unpinned)
- README skill table: dembrandt >= 0.23.1 (was stale 0.12.10)
- test.yml: permissions: contents: read

Coupling to the CLI: >=0.23.1 is the true minimum (<=0.23.0 fails McpDepsMissingError). Not bumped to 0.25.0 — these skills use the MCP engine unchanged since 0.23.1.