### PR TITLE
docs: cssVariables entries carry hex since dembrandt 0.26.0

### DIFF
--- a/skills/extract-design/SKILL.md
+++ b/skills/extract-design/SKILL.md
@@ -133,7 +133,7 @@ Dembrandt returns a structured object. The key sections:
 ```
 colors.palette        — Deduplicated colors with confidence (high/medium/low)
 colors.semantic       — Primary, secondary, background, text, and accent detection
-colors.cssVariables   — Named CSS custom properties with LCH + OKLCH values
+colors.cssVariables   — Named CSS custom properties with hex + LCH + OKLCH values
 typography.styles     — Font family, size, weight, line-height per context
 typography.sources    — Google Fonts, Adobe Fonts, variable font detection
 spacing.commonValues  — Margin/padding scale with rem equivalents


### PR DESCRIPTION
One-line Output Structure update for the 0.26.0 schema addition.