### PR TITLE
docs(sizing-units): which values move when the user enlarges text

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Works with Claude Code and any agent harness that supports the Open Agent Skills
 | `elevation-and-depth` | Shadow scale, border-radius, card and modal patterns |
 | `button-states` | Six states: rest, hover, active, focus, disabled, loading |
 | `component-family-consistency` | Buttons, inputs, pills: shared radius, colour, height |
+| `sizing-units` | px vs rem vs relative: which values move when the user enlarges text |
 
 **Layout & Structure**
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "skills/elevation-and-depth",
     "skills/button-states",
     "skills/component-family-consistency",
+    "skills/sizing-units",
     "skills/layout-paradigms-and-consistency",
     "skills/gestalt-ui-organisation",
     "skills/visual-emphasis-and-hierarchy",

--- a/skills/component-family-consistency/SKILL.md
+++ b/skills/component-family-consistency/SKILL.md
@@ -114,20 +114,22 @@ Components at the same visual scale share height and internal padding.
 
 ```css
 /* Default (md) size */
---component-height-md:    40px;
---component-padding-x-md: 12px;
---component-padding-y-md: 8px;
+--component-height-md:    2.5rem;    /* 40px */
+--component-padding-x-md: 0.75rem;   /* 12px */
+--component-padding-y-md: 0.5rem;    /* 8px  */
 
 /* Small */
---component-height-sm:    32px;
---component-padding-x-sm: 8px;
---component-padding-y-sm: 6px;
+--component-height-sm:    2rem;      /* 32px */
+--component-padding-x-sm: 0.5rem;    /* 8px  */
+--component-padding-y-sm: 0.375rem;  /* 6px  */
 
 /* Large */
---component-height-lg:    48px;
---component-padding-x-lg: 16px;
---component-padding-y-lg: 10px;
+--component-height-lg:    3rem;      /* 48px */
+--component-padding-x-lg: 1rem;      /* 16px */
+--component-padding-y-lg: 0.625rem;  /* 10px */
 ```
+
+Heights and text padding are in rem so a control still contains its label when the user enlarges text; borders and shadows stay in px. See [[sizing-units]].
 
 A button and an input placed next to each other must be the same height. This is not cosmetic — mismatched heights break form layouts and signal disorder.
 
@@ -137,7 +139,7 @@ A button and an input placed next to each other must be the same height. This is
 - a fluid or clamped font size changes the line box at some viewports and not others,
 - an item whose content is an avatar or icon rather than text has a different intrinsic height.
 
-Give every control on a line the same explicit height and centre its content. With `box-sizing: border-box` — the default in Tailwind and most resets — the border is absorbed into that height rather than added to it, so outlined and ghost variants match exactly and a variant can gain or lose its border without moving anything.
+Give every control on a line the same explicit height and centre its content. Set it as `min-height`, so the shape holds at rest and yields rather than clips when the content is larger than you planned. With `box-sizing: border-box` — the default in Tailwind and most resets — the border is absorbed into that height rather than added to it, so outlined and ghost variants match exactly and a variant can gain or lose its border without moving anything.
 
 **A derived height is also a defect you cannot search for.** An explicit height is one token you can grep and diff. A derived one is an emergent property of three separate declarations, so a row can be wrong in one control out of eight and no query finds it: in utility-class codebases the same padding appears in different orders (`rounded-md px-3 py-2` and `rounded-md border transition-colors px-3 py-2`), and a find-and-replace fixes some of them and silently skips the rest. Each miss is 2px, invisible on its own, and the reason the row still looks broken after you "fixed" it.
 

--- a/skills/dembrandt/SKILL.md
+++ b/skills/dembrandt/SKILL.md
@@ -84,6 +84,7 @@ Sub-skills (load as needed):
 - `elevation-and-depth` — shadow scale, border-radius, card and modal patterns
 - `button-states` — six states: rest, hover, active, focus, disabled, loading
 - `component-family-consistency` — buttons, inputs, pills: shared radius, colour, height
+- `sizing-units` — px vs rem vs relative: which values move when the user enlarges text
 - `status-colors-and-errors` — minimal semantic colours, error recovery, prevention
 
 **Gate:** Tokens defined and consistent across component family.

--- a/skills/sizing-units/SKILL.md
+++ b/skills/sizing-units/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: sizing-units
+description: Which CSS unit a value should be written in. rem for anything a text-size preference must move — type, control heights, padding around text. px only for what must not move — hairlines, borders, shadow offsets. Relative units for layout widths. Use when defining spacing and sizing tokens, choosing between px and rem, setting control heights, writing media queries, or fixing a layout that breaks when the user enlarges text.
+metadata:
+  priority: 5
+  pathPatterns:
+    - "design-system/**"
+    - "ui/**"
+    - "**/tokens*"
+    - "**/*.css"
+    - "**/tailwind.config.*"
+    - "components/**"
+    - "src/components/**"
+  promptSignals:
+    phrases:
+      - "rem"
+      - "px"
+      - "em"
+      - "spacing scale"
+      - "sizing tokens"
+      - "root font size"
+      - "text zoom"
+      - "which unit"
+retrieval:
+  aliases:
+    - px vs rem
+    - css units
+    - spacing units
+    - sizing tokens
+    - root font size
+    - text scaling
+  intents:
+    - decide between px and rem for spacing
+    - define a spacing scale
+    - fix a layout that breaks when text is enlarged
+    - choose units for media queries
+    - set control heights that survive text scaling
+  examples:
+    - should spacing be in rem or px
+    - our buttons clip when the user enlarges text
+    - what unit for border radius and shadows
+    - should media queries use px or em
+---
+
+# Sizing Units
+
+## The Question the Unit Answers
+
+A unit is not a formatting preference. It is a declaration of what happens to a value when the user enlarges text.
+
+- `rem` — this value belongs to the text and must grow with it.
+- `px` — this value belongs to the screen and must stay put.
+- `%`, `fr`, `ch`, `clamp()`, `min()` — this value belongs to the available space.
+
+Pick the unit by answering that question, not by picking a house style and applying it everywhere. Both absolutist positions — all-rem and all-px — produce defects, and they are different defects.
+
+## Zoom Is Not the Font-Size Setting
+
+The common argument for px everywhere is that browsers already have full-page zoom, so the root font size can be ignored. They are separate controls serving separate people.
+
+- **Full-page zoom** magnifies everything, layout included. It buys larger text at the cost of horizontal scrolling and fewer items per screen.
+- **The browser's default font size** enlarges text and leaves the layout alone. This is what a user with low vision sets once, years ago, and never touches again. They will not switch to zoom because your product ignored it.
+
+A product that hard-codes every dimension in px answers the first user and silently refuses the second. WCAG 2.2 SC 1.4.4 (Resize Text) requires text to reach 200% without loss of content or function, and SC 1.4.10 (Reflow) requires the page to survive it in a single column. See [[wcag-accessibility]].
+
+## Use rem For
+
+**Typography.** Every font size and line height. See [[modular-scale-typography]].
+
+**Padding around text.** A button's inner padding in px means large text presses against its edges. In rem the breathing room scales with the words it surrounds.
+
+**Control heights.** A 40px control holding 24px text is broken. Write the height token in rem and it stays a control-shaped control at every text size. See [[component-family-consistency]].
+
+**Measure.** `max-width` on a text column: `65ch` or a rem value, never px.
+
+**Gaps between text-bearing blocks.** Stack spacing in a form or an article is part of the reading rhythm.
+
+## Use px For
+
+**Hairlines and borders.** `1px` is one device pixel by intent. In rem it becomes `1.25px` at a larger root size and renders as a blurry smear.
+
+**Shadow offsets and blur.** Elevation is a screen-space effect. See [[elevation-and-depth]].
+
+**Small icons inside controls** where the icon is a fixed glyph rather than text.
+
+**Sub-pixel corrections** — the `-1px` that makes two borders overlap instead of doubling.
+
+## Use Relative Units For
+
+Layout widths and gaps. This is where the "lock it in px so it stays stable" instinct goes wrong: a px-locked container is not stable, it is brittle. The text inside it still grows, and a fixed box is exactly what makes growing text clip.
+
+```css
+/* Brittle — the box cannot absorb anything */
+.card   { width: 320px; height: 180px; }
+.sidebar { width: 280px; }
+
+/* Resilient */
+.card    { max-width: 20rem; min-height: 11.25rem; }
+.sidebar { width: clamp(16rem, 22%, 22rem); }
+```
+
+**`min-height`, never `height`,** on anything containing text. A fixed height cannot grow; a minimum height holds the shape at rest and yields when it must.
+
+## Media Queries
+
+Use `em` in media queries. Media-query `rem` and `em` both resolve against the browser's default font size, ignoring any `html { font-size }` you set — so `em` is the honest spelling, and both respect the user's preference where a px breakpoint does not. A user with a large default font size gets the layout their effective text size warrants, not the one their device width claims.
+
+```css
+@media (min-width: 48em) { /* ~768px at default settings */ }
+```
+
+## Do Not Reset the Root
+
+```css
+html { font-size: 62.5%; } /* Do not do this */
+```
+
+The 62.5% trick exists to make rem arithmetic easy — `1.6rem` for 16px. It buys you mental arithmetic and pays for it by overriding the user's stated preference by default. Keep the root at the browser default and let the tooling do the division.
+
+## Review Checklist
+
+- [ ] Is every font size, line height, and text-adjacent padding in rem?
+- [ ] Are borders, hairlines, and shadow offsets in px?
+- [ ] Does any element containing text use `height` rather than `min-height`?
+- [ ] Are container widths relative (`%`, `fr`, `clamp()`, `max-width`) rather than fixed px?
+- [ ] Are media-query breakpoints in `em`?
+- [ ] Is `html { font-size }` left at the browser default?
+- [ ] At a 200% browser font-size setting, does every control still contain its label, with no clipping and no horizontal page scroll?


### PR DESCRIPTION
Adds a `sizing-units` skill: the unit declares what happens to a value when the user enlarges text — rem for type, text padding and control heights; px for hairlines, borders and shadow offsets; relative units for layout widths.

Covers the px-everywhere argument directly: full-page zoom and the browser's default font size are separate controls for separate people, and locking containers in px is what makes growing text clip (WCAG 1.4.4 / 1.4.10).

Also updates `component-family-consistency`: its control-height and padding tokens move from px to rem, and the explicit height becomes `min-height` so the row holds its shape at rest and yields instead of clipping.