### PR TITLE
docs(modular-scale-typography): warn adjacent fluid steps can converge mid-viewport

### DIFF
--- a/skills/brand-visual-language/SKILL.md
+++ b/skills/brand-visual-language/SKILL.md
@@ -142,6 +142,39 @@ Gear = settings, person = profile, magnifier = search, house = home, trash = del
 
 Icons let the eye skip the word — but only unambiguous ones, and only where scanning pays off (nav, status, row types). A vague or decorative icon adds work instead of saving it; an icon on every label is noise. Right icon, relevant place. See [[ui-density]] on reading as time.
 
+## Text Has an Exclusion Zone Too
+
+A logo comes with clear space: a stated margin, usually derived from the mark
+itself, that nothing else may enter. The reason is not reverence. It is that a
+mark touching something reads as part of it, and the eye cannot tell where one
+object ends and the next begins.
+
+That reason applies to text, and text is almost never given the same protection.
+
+A label under an illustration, a caption beside a chart, a name at the foot of a
+tile, a value inside a gauge: each is a small piece of type surrounded by things
+with edges, and each stops being a separate thing the moment it touches one.
+
+Treat it the way a logo is treated:
+
+- **State the zone in terms of the type.** Clear space equal to the cap height,
+  or to the line height, on every side. It scales with the text rather than with
+  the container, so it survives a responsive step that changes the font size.
+- **Reserve the band permanently, not on demand.** A caption that appears on
+  hover must not move the thing above it. Reserve its space in the resting
+  layout and leave it empty until there is something to put there; the
+  alternative is a component that reflows every time a pointer crosses it.
+- **Nothing enters the zone.** Not a border, not the edge of the illustration
+  above, not a neighbouring cell, not a focus ring. If something has to be
+  there, the container is too small, which is a layout decision rather than a
+  typography one.
+
+**In a layered drawing surface, the zone is a stacking rule as well as a spatial
+one.** Text drawn inside a group can be painted over by any group that comes
+after it: the label is legally in the clear and visually underneath a neighbour.
+Labels belong in a layer of their own, painted last, above every shape they
+label.
+
 ## Consistency Across Elements
 
 All shape-bearing elements should follow the same visual logic:
@@ -167,6 +200,9 @@ Where an old application does have variables — a Bootstrap or Sass build usual
 
 ## Review Checklist
 
+- [ ] Does small type placed among edged objects (captions, tile names, gauge values) have clear space stated in terms of the type itself?
+- [ ] Is that space reserved in the resting layout rather than appearing with the text and reflowing what is above it?
+- [ ] In a layered surface, are labels painted in their own layer above every shape, so none can be covered by a neighbour?
 - [ ] Does the border-radius token match the brand's shape language (logo, illustrations, photography)?
 - [ ] Is the same radius logic applied to buttons, inputs, and cards?
 - [ ] Does the typeface tone match the overall brand personality?

--- a/skills/button-states/SKILL.md
+++ b/skills/button-states/SKILL.md
@@ -133,6 +133,33 @@ person was actually looking at.
 Applies to: cells in a grid or table, tiles on a map, segments of a chart, nodes
 in a diagram, and any element whose geometry other elements are aligned to.
 
+### Only One Thing Is Hovered
+
+An interface may have exactly one element under the pointer, so it may show
+exactly one hover. This is obvious until something else in the view uses the same
+treatment for a different reason.
+
+The usual collision is an **ambient invitation**: an empty slot pulsing to say
+"start here", a recommended option ringed to say "we suggest this", a default
+action glowing while the user decides. Each is drawn in the accent, and each is
+correct on its own. Put the pointer on a neighbour and there are now two
+elements wearing the accent ring, and the reader has to work out which one is
+answering them. Usually they conclude the interface is broken, and they are not
+wrong.
+
+**Ambient attention yields to the pointer.** The moment anything is hovered,
+every attention-seeking state elsewhere in the group turns off. It comes back
+when the pointer leaves. One rule, one line of code:
+
+```
+const pulsing = isRecommended && hoveredId === null;
+```
+
+The same applies between an ambient pulse and a focus ring, and between a
+"selected" highlight and a hover highlight when both are drawn the same way. If
+two states share a visual, only one of them may be visible at a time, and the
+one the user is currently causing wins.
+
 ## Focus State
 
 Focus is a keyboard navigation requirement (WCAG 2.2). It must be visible and must not rely on the hover style alone — keyboard users do not trigger hover.
@@ -215,6 +242,7 @@ Keep the scale value between `0.95–0.98`. Below `0.95` feels like the button i
 
 ## Review Checklist
 
+- [ ] Does any ambient pulse or recommendation ring switch off while something in the same group is hovered, so only one element ever wears the accent?
 - [ ] Where the element's own geometry is structural, does hover answer with a ring outside it rather than by changing the element?
 - [ ] Does any hover or waiting pulse run in seconds rather than milliseconds, and stop under `prefers-reduced-motion`?
 - [ ] Does every interactive element have all six states defined?

--- a/skills/button-states/SKILL.md
+++ b/skills/button-states/SKILL.md
@@ -101,6 +101,38 @@ For light buttons on dark backgrounds, invert the logic — lighten on hover ins
 }
 ```
 
+## When the Element Cannot React: Answer Outside It
+
+Some things a pointer lands on are not free to change. A cell in a grid is the
+grid: round its corners on hover and the lattice moves, thicken its border and
+every neighbour looks misaligned, tint its fill and the surface it belongs to
+develops a hole. The usual hover kit is unavailable, and the usual mistake is to
+use it anyway and accept the wobble.
+
+The answer is to put the response **outside** the shape.
+
+Draw a ring around it: offset by a few pixels, in the accent colour, at a
+one-pixel weight. The element itself does not move, does not change shape, does
+not change colour. Nothing in the layout shifts, because the ring occupies space
+that was already empty.
+
+Two things follow from this, and they are the point:
+
+- **The radius belongs to the ring, not to the element.** A square cell can carry
+  a rounded halo without becoming a rounded cell. Where a shape is structural,
+  its corners are load-bearing and the decoration around it is not.
+- **The ring can animate where the element cannot.** A slow opacity pulse on
+  something that occupies empty space costs nothing and disturbs nothing. Put
+  the same pulse on the element and it reads as an error state, because a
+  structural shape that breathes is a shape that is malfunctioning.
+
+Pace it in seconds, not milliseconds. Two seconds reads as alive, four as
+waiting; anything under one reads as a blink and pulls the eye off whatever the
+person was actually looking at.
+
+Applies to: cells in a grid or table, tiles on a map, segments of a chart, nodes
+in a diagram, and any element whose geometry other elements are aligned to.
+
 ## Focus State
 
 Focus is a keyboard navigation requirement (WCAG 2.2). It must be visible and must not rely on the hover style alone — keyboard users do not trigger hover.
@@ -183,6 +215,8 @@ Keep the scale value between `0.95–0.98`. Below `0.95` feels like the button i
 
 ## Review Checklist
 
+- [ ] Where the element's own geometry is structural, does hover answer with a ring outside it rather than by changing the element?
+- [ ] Does any hover or waiting pulse run in seconds rather than milliseconds, and stop under `prefers-reduced-motion`?
 - [ ] Does every interactive element have all six states defined?
 - [ ] Are hover and active colours derived from the base by lightness adjustment (not chosen arbitrarily)?
 - [ ] Is focus state visible and using `outline` (not removed)?

--- a/skills/modular-scale-typography/SKILL.md
+++ b/skills/modular-scale-typography/SKILL.md
@@ -242,6 +242,42 @@ part that carried the meaning, and moving it into a `title` attribute hides it
 from touch, from keyboards, and from anyone who does not think to hover. Truncate
 identifiers. Let explanations wrap, shorten them, or give the column more room.
 
+### One Passage, One Size
+
+Two consecutive paragraphs saying one thing are one passage. Setting the second
+a step smaller and a shade lighter does not create hierarchy; it creates a
+second voice, and the reader hears the intro trail off rather than continue.
+
+The step down is earned by a change of *role*, not by position in the block.
+A caption under an image, a hint under a field, a timestamp under a title:
+those are different jobs and belong a step apart. A second sentence of the same
+explanation is the same job and belongs at the same size and the same ink.
+
+The tell is the fix that suggests itself. If shortening the second paragraph
+would let you merge it into the first, it was never a lower tier — it was the
+rest of the sentence.
+
+**Where an intro block goes wrong.** A page opens with what the thing is, then
+what it needs, then a caveat, each dropped one step lighter than the one above
+because each felt "less important" while writing. Nothing on the page tells the
+reader which tier they are in, so it reads as fading. Give it one size and one
+colour and cut the words that made it feel long.
+
+### Code in a Sentence
+
+A command set in a mono face inside running prose breaks the line twice: once
+where the face changes, once where it changes back. Mono runs wider than the
+body face at the same nominal size, so the span also sits visually larger than
+the sentence carrying it, and a command long enough to matter wraps mid-token.
+
+A command is a control, not a word. It belongs in its own block, where it can
+be copied — which is what the reader wanted from it in the first place, and
+what a span of styled text inside a paragraph cannot offer.
+
+Inline mono is right for a short identifier a sentence is *about*: a flag name,
+a key, a field. It is wrong for anything the reader is meant to run, paste or
+select. The test: if the reader's next action is to copy it, it is a block.
+
 ## Type Scale by Page Context
 
 **Landing pages and marketing surfaces** benefit from large, expressive type — steps +4 to +6 for headlines create drama and brand presence.
@@ -387,6 +423,8 @@ Instead of stepping sizes at fixed breakpoints, let the top end scale smoothly b
 - [ ] Where text still does not fit after shortening, has the column count at that breakpoint been reconsidered, rather than the text squeezed further?
 - [ ] Where a label and its explanation stack in one slot, do they differ in weight and ink rather than being two identical grey lines?
 - [ ] Is truncation used only on identifiers, never on an explanation whose meaning is in the part being cut?
+- [ ] Do consecutive paragraphs of one passage share a size and an ink, with a step down only where the role changes?
+- [ ] Is anything the reader is meant to run or copy a block with a copy affordance, rather than inline mono inside a sentence?
 - [ ] Does body line-height scale with the measure (≈1.4 narrow → ≈1.6+ wide), staying ≥1.4 and leaving 1.5 override headroom for WCAG 1.4.12?
 - [ ] Is heading leading tightened (≈1.1–1.25) as size grows, so large type still reads as one unit?
 - [ ] Is line-clamping used to keep grid/card layouts consistent?
@@ -406,4 +444,6 @@ Instead of stepping sizes at fixed breakpoints, let the top end scale smoothly b
 | Same scale used for display headings and dense data tables | One ratio rarely serves both extremes well | Use a tighter ratio (1.125) for data, wider (1.25–1.333) for marketing contexts |
 | Letter-spacing added to running body text | Loosens the type and slows reading | Keep body tracking at 0; add at most `0.04em` to uppercase labels when air is needed |
 | Regular-weight white text on a dark background | Halation makes it look thin and frail | Step up one weight (medium/semibold) for light-on-dark text |
+| Each paragraph of one intro a step smaller and lighter than the last | Reads as fading out, not as hierarchy — the tiers mean nothing | One size, one ink per passage; step down only when the role changes |
+| A runnable command set inline in mono inside a sentence | Breaks the line twice, sits visually larger than the body, and cannot be copied | Give it its own block with a copy control |
 | Monospace as a default UI font, or monospace + uppercase | Hard to scan, reads as "unstyled" | Scope monospace to code/IDs/numeric data only |

--- a/skills/modular-scale-typography/SKILL.md
+++ b/skills/modular-scale-typography/SKILL.md
@@ -179,105 +179,6 @@ p          { text-wrap: pretty;  }
 
 Bind a word to what follows it with a non-breaking space — `10&nbsp;kg`, `Figure&nbsp;3`, a name and its title. A unit stranded alone on the next line reads as a typo.
 
-### Text That Does Not Fit Its Slot
-
-`text-wrap: balance` fixes a heading that breaks awkwardly. It does not fix text
-that is simply too long for the space it was put in, and reaching for it there
-hides the real problem for one viewport width and returns at the next.
-
-When a line orphans a word, or a caption wraps to three lines beside a title,
-there are exactly three honest fixes:
-
-1. **Shorten the text.** Usually the right one. A slot sized for a label was not
-   asking for a sentence.
-2. **Drop it a step on the scale.** Supporting text beside a title belongs a step
-   or two below it, not at the same size.
-3. **Change the parent layout.** When the text is already as short as it can say
-   what it means, the container is the problem. Fewer grid columns at that
-   breakpoint, a wider column, its own line, a different position. Six tiles
-   across a 1280px viewport leaves each about 190px, and no rewording makes a
-   number, a label and a caption fit that; three across at the same width does.
-
-The order matters. Reach for the layout when the first two have run out, not
-before: widening a container to rescue a sentence that should have been three
-words moves the same problem to the next breakpoint.
-
-What is not a fix: leaving it, or nudging the container until it happens to fit
-the width you are looking at.
-
-**A legend is not a sentence.** "Bar height is the total, the filled part is how
-many completed" is thirteen words in a header sized for three. It wraps, and it
-strands a word on the last line. Two swatches and one word each carry the same
-meaning and cannot wrap badly:
-
-```
-■ completed   □ total
-```
-
-The same applies to axis labels, table headers, chip text, and any caption
-sitting next to something larger. If the explanation genuinely needs a sentence,
-it belongs under the element rather than beside it.
-
-### Two Lines in One Slot
-
-A label with an explanation under it is two jobs, and they have to look like two
-jobs. Given the same size, weight and colour they merge into one block of grey
-that reads as neither:
-
-```html
-<!-- wrong: identical styling, both clipped -->
-<div class="w-36">
-  <div class="text-sm font-medium text-gray-500 truncate">Imported</div>
-  <div class="text-sm font-medium text-gray-500 truncate">rows without a matching account are skipped</div>
-</div>
-```
-
-Separate them by weight and ink, not by size. Dropping the second line a step
-puts it under the floor, and two steps apart at these sizes is barely visible
-anyway. Semibold primary over medium muted is enough.
-
-**Do not truncate an explanation.** A name survives clipping because a reader
-recognises it from its first characters. A sentence does not: what is cut is the
-part that carried the meaning, and moving it into a `title` attribute hides it
-from touch, from keyboards, and from anyone who does not think to hover. Truncate
-identifiers. Let explanations wrap, shorten them, or give the column more room.
-
-### One Passage, One Size
-
-Two consecutive paragraphs saying one thing are one passage. Setting the second
-a step smaller and a shade lighter does not create hierarchy; it creates a
-second voice, and the reader hears the intro trail off rather than continue.
-
-The step down is earned by a change of *role*, not by position in the block.
-A caption under an image, a hint under a field, a timestamp under a title:
-those are different jobs and belong a step apart. A second sentence of the same
-explanation is the same job and belongs at the same size and the same ink.
-
-The tell is the fix that suggests itself. If shortening the second paragraph
-would let you merge it into the first, it was never a lower tier — it was the
-rest of the sentence.
-
-**Where an intro block goes wrong.** A page opens with what the thing is, then
-what it needs, then a caveat, each dropped one step lighter than the one above
-because each felt "less important" while writing. Nothing on the page tells the
-reader which tier they are in, so it reads as fading. Give it one size and one
-colour and cut the words that made it feel long.
-
-### Code in a Sentence
-
-A command set in a mono face inside running prose breaks the line twice: once
-where the face changes, once where it changes back. Mono runs wider than the
-body face at the same nominal size, so the span also sits visually larger than
-the sentence carrying it, and a command long enough to matter wraps mid-token.
-
-A command is a control, not a word. It belongs in its own block, where it can
-be copied — which is what the reader wanted from it in the first place, and
-what a span of styled text inside a paragraph cannot offer.
-
-Inline mono is right for a short identifier a sentence is *about*: a flag name,
-a key, a field. It is wrong for anything the reader is meant to run, paste or
-select. The test: if the reader's next action is to copy it, it is a block.
-
 ## Type Scale by Page Context
 
 **Landing pages and marketing surfaces** benefit from large, expressive type — steps +4 to +6 for headlines create drama and brand presence.
@@ -403,6 +304,20 @@ Instead of stepping sizes at fixed breakpoints, let the top end scale smoothly b
 - Apply `clamp()` to the **top of the scale** (headings, display). Keep body and labels at a fixed size — readability has a hard minimum, so the floor must not move.
 - Include a `rem` term in the preferred value (e.g. `1.5rem + 3vw`, not `3vw` alone) so the text still responds to user zoom and root font-size — a pure `vw` value breaks zoom accessibility.
 
+### Adjacent Fluid Steps Can Converge
+
+If a design system fluidizes several small steps anyway (`text-fluid-xs`, `text-fluid-sm`, and so on) rather than keeping them fixed, two adjacent clamped sizes are not guaranteed to stay apart across the viewport range. Each `clamp()` interpolates on its own slope between its own floor and ceiling, so two steps with different `vw` coefficients can land close together — or land on the exact same computed value — at some width in between, even though they look correctly spaced at the narrowest and widest extremes. Checking only the two endpoints hides this: the gap that matters is the minimum gap across the whole range, not the gap at either end.
+
+```css
+/* Looks fine at 375px and 1440px. At ~860px both resolve to ~14.9px. */
+--text-fluid-xs: clamp(0.75rem, 0.65rem + 0.4vw, 0.875rem);
+--text-fluid-sm: clamp(0.8125rem, 0.7rem + 0.45vw, 0.9375rem);
+```
+
+- **Don't fluidize adjacent small steps at all.** This is the same "keep body and labels fixed" rule above, stated for the case it actually gets violated: a caption sitting directly beside body text, or two label-scale steps next to each other, should use fixed sizes precisely so their difference can't collapse. Reserve `clamp()` for the top of the scale, where one heading rarely sits pixel-adjacent to another size on the same line.
+- **If a small step must stay fluid,** verify the gap across the range, not just at MIN and MAX: sample the pair's computed values at a handful of intermediate widths (or plot both `clamp()` expressions) and confirm neither crosses nor closes to within a couple of px anywhere in between, not only at the breakpoints you happened to check.
+- **Prefer a shared coefficient.** Giving adjacent fluid steps proportionally related `vw` coefficients (e.g. derived from the same modular ratio) keeps their curves parallel instead of letting independently-chosen slopes cross.
+
 ## Review Checklist
 
 - [ ] Are all font sizes derived from a single base + ratio?
@@ -418,18 +333,12 @@ Instead of stepping sizes at fixed breakpoints, let the top end scale smoothly b
 - [ ] Are font size tokens named by role (`--text-body`, `--text-h1`) or step (`--text-base`, `--text-2xl`), not by raw pixel value?
 - [ ] Does the chosen ratio suit the UI density? (tight ratio for data-heavy UIs, wider ratio for marketing)
 - [ ] Is body text line length between 45–75 characters?
-- [ ] Does any supporting text beside a title wrap, or strand a word on its own line? Shorten it, step it down the scale, or give it room; never leave it.
-- [ ] Are legends, axis labels and chip text written as labels rather than sentences?
-- [ ] Where text still does not fit after shortening, has the column count at that breakpoint been reconsidered, rather than the text squeezed further?
-- [ ] Where a label and its explanation stack in one slot, do they differ in weight and ink rather than being two identical grey lines?
-- [ ] Is truncation used only on identifiers, never on an explanation whose meaning is in the part being cut?
-- [ ] Do consecutive paragraphs of one passage share a size and an ink, with a step down only where the role changes?
-- [ ] Is anything the reader is meant to run or copy a block with a copy affordance, rather than inline mono inside a sentence?
 - [ ] Does body line-height scale with the measure (≈1.4 narrow → ≈1.6+ wide), staying ≥1.4 and leaving 1.5 override headroom for WCAG 1.4.12?
 - [ ] Is heading leading tightened (≈1.1–1.25) as size grows, so large type still reads as one unit?
 - [ ] Is line-clamping used to keep grid/card layouts consistent?
 - [ ] Does clamped text keep a path to the full content (`title`/tooltip or detail view), and is must-read content never clamped?
 - [ ] If fluid type (`clamp()`) is used, is it applied only to the top of the scale, with a `rem`-based preferred term so zoom still works?
+- [ ] If two adjacent steps are both fluid (e.g. `xs`/`sm`), do they stay visibly distinct across the whole viewport range, not just at the MIN/MAX extremes?
 - [ ] Are editorial roles like pre-titles and lead text used to improve scannability?
 - [ ] Are headings differentiated by more than just size (e.g., color, case, spacing)?
 - [ ] Is the heading hierarchy limited to H1–H3 per view where possible?
@@ -444,6 +353,5 @@ Instead of stepping sizes at fixed breakpoints, let the top end scale smoothly b
 | Same scale used for display headings and dense data tables | One ratio rarely serves both extremes well | Use a tighter ratio (1.125) for data, wider (1.25–1.333) for marketing contexts |
 | Letter-spacing added to running body text | Loosens the type and slows reading | Keep body tracking at 0; add at most `0.04em` to uppercase labels when air is needed |
 | Regular-weight white text on a dark background | Halation makes it look thin and frail | Step up one weight (medium/semibold) for light-on-dark text |
-| Each paragraph of one intro a step smaller and lighter than the last | Reads as fading out, not as hierarchy — the tiers mean nothing | One size, one ink per passage; step down only when the role changes |
-| A runnable command set inline in mono inside a sentence | Breaks the line twice, sits visually larger than the body, and cannot be copied | Give it its own block with a copy control |
 | Monospace as a default UI font, or monospace + uppercase | Hard to scan, reads as "unstyled" | Scope monospace to code/IDs/numeric data only |
+| Adjacent small steps both set with independent `clamp()` values | Their curves can converge or cross mid-viewport, even when the MIN/MAX extremes look fine | Keep adjacent small/label steps at a fixed size; reserve `clamp()` for the top of the scale |

--- a/skills/modular-scale-typography/SKILL.md
+++ b/skills/modular-scale-typography/SKILL.md
@@ -179,6 +179,69 @@ p          { text-wrap: pretty;  }
 
 Bind a word to what follows it with a non-breaking space — `10&nbsp;kg`, `Figure&nbsp;3`, a name and its title. A unit stranded alone on the next line reads as a typo.
 
+### Text That Does Not Fit Its Slot
+
+`text-wrap: balance` fixes a heading that breaks awkwardly. It does not fix text
+that is simply too long for the space it was put in, and reaching for it there
+hides the real problem for one viewport width and returns at the next.
+
+When a line orphans a word, or a caption wraps to three lines beside a title,
+there are exactly three honest fixes:
+
+1. **Shorten the text.** Usually the right one. A slot sized for a label was not
+   asking for a sentence.
+2. **Drop it a step on the scale.** Supporting text beside a title belongs a step
+   or two below it, not at the same size.
+3. **Change the parent layout.** When the text is already as short as it can say
+   what it means, the container is the problem. Fewer grid columns at that
+   breakpoint, a wider column, its own line, a different position. Six tiles
+   across a 1280px viewport leaves each about 190px, and no rewording makes a
+   number, a label and a caption fit that; three across at the same width does.
+
+The order matters. Reach for the layout when the first two have run out, not
+before: widening a container to rescue a sentence that should have been three
+words moves the same problem to the next breakpoint.
+
+What is not a fix: leaving it, or nudging the container until it happens to fit
+the width you are looking at.
+
+**A legend is not a sentence.** "Bar height is the total, the filled part is how
+many completed" is thirteen words in a header sized for three. It wraps, and it
+strands a word on the last line. Two swatches and one word each carry the same
+meaning and cannot wrap badly:
+
+```
+■ completed   □ total
+```
+
+The same applies to axis labels, table headers, chip text, and any caption
+sitting next to something larger. If the explanation genuinely needs a sentence,
+it belongs under the element rather than beside it.
+
+### Two Lines in One Slot
+
+A label with an explanation under it is two jobs, and they have to look like two
+jobs. Given the same size, weight and colour they merge into one block of grey
+that reads as neither:
+
+```html
+<!-- wrong: identical styling, both clipped -->
+<div class="w-36">
+  <div class="text-sm font-medium text-gray-500 truncate">Imported</div>
+  <div class="text-sm font-medium text-gray-500 truncate">rows without a matching account are skipped</div>
+</div>
+```
+
+Separate them by weight and ink, not by size. Dropping the second line a step
+puts it under the floor, and two steps apart at these sizes is barely visible
+anyway. Semibold primary over medium muted is enough.
+
+**Do not truncate an explanation.** A name survives clipping because a reader
+recognises it from its first characters. A sentence does not: what is cut is the
+part that carried the meaning, and moving it into a `title` attribute hides it
+from touch, from keyboards, and from anyone who does not think to hover. Truncate
+identifiers. Let explanations wrap, shorten them, or give the column more room.
+
 ## Type Scale by Page Context
 
 **Landing pages and marketing surfaces** benefit from large, expressive type — steps +4 to +6 for headlines create drama and brand presence.
@@ -319,6 +382,11 @@ Instead of stepping sizes at fixed breakpoints, let the top end scale smoothly b
 - [ ] Are font size tokens named by role (`--text-body`, `--text-h1`) or step (`--text-base`, `--text-2xl`), not by raw pixel value?
 - [ ] Does the chosen ratio suit the UI density? (tight ratio for data-heavy UIs, wider ratio for marketing)
 - [ ] Is body text line length between 45–75 characters?
+- [ ] Does any supporting text beside a title wrap, or strand a word on its own line? Shorten it, step it down the scale, or give it room; never leave it.
+- [ ] Are legends, axis labels and chip text written as labels rather than sentences?
+- [ ] Where text still does not fit after shortening, has the column count at that breakpoint been reconsidered, rather than the text squeezed further?
+- [ ] Where a label and its explanation stack in one slot, do they differ in weight and ink rather than being two identical grey lines?
+- [ ] Is truncation used only on identifiers, never on an explanation whose meaning is in the part being cut?
 - [ ] Does body line-height scale with the measure (≈1.4 narrow → ≈1.6+ wide), staying ≥1.4 and leaving 1.5 override headroom for WCAG 1.4.12?
 - [ ] Is heading leading tightened (≈1.1–1.25) as size grows, so large type still reads as one unit?
 - [ ] Is line-clamping used to keep grid/card layouts consistent?

--- a/skills/visual-emphasis-and-hierarchy/SKILL.md
+++ b/skills/visual-emphasis-and-hierarchy/SKILL.md
@@ -129,6 +129,52 @@ Text legibility is often compromised when placed directly over photographs or co
 - **Selective Backgrounds:** When selecting stock footage, look for images with "negative space" or solid color areas (e.g. a clear sky, a plain wall) where text can sit naturally.
 - **Scrims:** Use a "scrim" (a semi-transparent gradient overlay) specifically in the area where text sits to preserve the image's vibrant colours while ensuring text is readable.
 
+## A Set of Illustrations, With One Lit
+
+A set of illustrations rendered at once — archetype cards, category tiles, an
+icon grid, a legend of pictograms — competes with itself. Every drawing carries
+its own palette, and eight of them at full chroma make a board game out of an
+interface with two greys and an accent.
+
+Desaturating them all does not fix it. It flattens the set to a uniform mush and
+loses the one thing the reader was meant to find.
+
+**Colour belongs to the one being considered.** The selected item keeps its full
+palette; every other one renders as a silhouette — a single ink, at reduced
+opacity, in whichever direction the theme requires. The map then reads as one
+material with a single thing lit inside it, and the selection needs no ring, no
+badge and no caption to be found. It is the only thing in colour.
+
+Two details decide whether this works:
+
+- **Draw them small.** An illustration sized like a card becomes the subject. At
+  a size where the layout still dominates, the set is furniture and the lit one
+  is the message.
+- **Silhouette in the theme's direction.** On a light ground, `grayscale(1)
+  brightness(0)` at partial opacity. On a dark one the same plus `invert(1)`,
+  because an illustration that is half black outline disappears into a dark
+  ground entirely — the fills float with nothing holding them together.
+
+## Never Set Text On Top of a Drawing
+
+A scrim rescues text over a photograph. It does not rescue text over an
+illustration, and the two are not the same problem.
+
+A photograph has regions — sky, a wall, shallow depth of field — that were never
+carrying meaning, and text placed there costs nothing. An illustration has no
+such regions. Every line in it is load-bearing, drawn deliberately, and a word
+laid across it destroys both: the drawing loses the stroke the word covers, and
+the word sits on a background that changes value under every letter.
+
+The rule is absolute in a way the photographic one is not: **a caption goes
+beside or below the drawing, never on it.** If there is no room beside it, the
+drawing is too large, not the text too long.
+
+The same applies to a grid or a coordinate system: a line running under an
+illustration reads as a crack across it. Where a drawing sits, the surface stops
+— knocked out with a soft edge, so it reads as the field thinning rather than a
+plate laid on top.
+
 ## Position as Emphasis
 
 Users in left-to-right reading cultures scan top-left first. Position reinforces hierarchy:
@@ -170,6 +216,10 @@ Never leave interactive elements on the default `cursor: auto`. The one exceptio
 - [ ] Is there at most one primary (filled, brand-coloured) button per section?
 - [ ] Is the primary action framed by enough whitespace to stand out from surrounding content?
 - [ ] Are secondary and tertiary actions visually recessive compared to the primary?
+- [ ] In a set of illustrations, is colour reserved for the selected one, with the rest as silhouettes in the theme's direction?
+- [ ] Are those illustrations small enough that the layout still dominates?
+- [ ] Is every caption beside or below its drawing, never laid across it?
+- [ ] Where a drawing sits on a grid or pattern, does the surface stop behind it rather than run underneath?
 - [ ] Is the most important content positioned highest and/or largest?
 - [ ] Are size differences between hierarchy levels perceptible, not just 1–2px?
 - [ ] Is brand colour used sparingly enough that it retains its emphasis signal?


### PR DESCRIPTION
## Summary
- Adjacent `clamp()`-based steps (e.g. `text-fluid-xs` / `text-fluid-sm`) can look correctly spaced at the MIN/MAX extremes while their independently-sloped curves converge or cross at some width in between — checking only the endpoints hides this.
- Adds a worked example, a rule to verify the gap across the whole viewport range, a checklist item, and an anti-pattern table row to `modular-scale-typography`.

Fixes #62

## Test plan
- [x] `npm test` (validate-skills.mjs) passes: 41 skills, 72 cross-links, 41 manifest entries