### PR TITLE
chore: sync with dembrandt v0.32.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dembrandt-skills",
-  "version": "0.3.30",
+  "version": "0.3.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dembrandt-skills",
-      "version": "0.3.30",
+      "version": "0.3.31",
       "devDependencies": {
         "js-yaml": "^4.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dembrandt-skills",
-  "version": "0.3.30",
+  "version": "0.3.31",
   "description": "Shareable UX and design system skills for AI agents — Gestalt, typography, modular scale, and more.",
   "scripts": {
     "test": "node test/validate-skills.mjs"


### PR DESCRIPTION
Automated sync triggered by [dembrandt v0.32.1](https://github.com/dembrandt/dembrandt/releases/tag/v0.32.1).

- Bumped `dembrandt-skills` patch version
- Updated CLI version references in skill files

**⚠ Manual check required before merging**
This automation only updates version numbers. Read the release notes above, then update `skills/extract-design/SKILL.md` by hand if the release changed any of:
- CLI flags, or an environment variable that changes behaviour
- The JSON output shape: new keys, renamed keys, or values that moved
- MCP tools or their parameters
- Anti-bot behaviour

A release with no new flags can still need every one of these.