### PR TITLE
a missing robots.txt is not an unreadable one

### DIFF
--- a/skills/extract-design/SKILL.md
+++ b/skills/extract-design/SKILL.md
@@ -212,9 +212,10 @@ meta.robotsWarnings   : pages robots.txt disallowed, whether that was the
                         is advisory by default, it does not block
                         extraction, and this is the only record of what it
                         flagged (dembrandt 0.31+). Set
-                        `DEMBRANDT_ENFORCE_ROBOTS=1` to make a disallow, or an
-                        unreadable robots.txt, skip the target with exit `4`
-                        (dembrandt 0.32+).
+                        `DEMBRANDT_ENFORCE_ROBOTS=1` to make a disallow, or a
+                        robots.txt we could not read, skip the target with exit
+                        `4`. A site with no robots.txt (404/410) is not a
+                        refusal and still runs (dembrandt 0.32+).
 ```
 
 ## Working with Extracted Tokens
@@ -343,7 +344,7 @@ Dembrandt handles common extraction challenges automatically:
 - **Slow sites** — use `--slow` for 3× timeouts on heavy JS bundles
 - **Cookie banners** — dismisses common CMP dialogs (OneTrust, cookielaw, GDPR patterns) automatically
 - **Bot detection bypass** — use `--stealth` to opt in to navigator spoofing and human mouse simulation; off by default so the tool identifies itself honestly
-- **robots.txt** — read once per origin and matched against the User-Agent the browser actually sends. Advisory by default; set `DEMBRANDT_ENFORCE_ROBOTS=1` for scheduled jobs and server-side use, where nobody is deciding what may be fetched, and a disallow or an unreadable file skips the target with exit `4` *(0.32+)*
+- **robots.txt** — read once per origin and matched against the User-Agent the browser actually sends. Advisory by default; set `DEMBRANDT_ENFORCE_ROBOTS=1` for scheduled jobs and server-side use, where nobody is deciding what may be fetched, and a disallow or a file we could not read skips the target with exit `4`. A missing robots.txt is not a refusal *(0.32+)*
 
 ## Checklist After Extraction
 


### PR DESCRIPTION
Two lines said an unreadable robots.txt skips the target under DEMBRANDT_ENFORCE_ROBOTS=1. Since 0.32.1 that is only half true: a 404 or 410 means there are no rules to honour and the run proceeds, while a refusal, a rate limit or a 5xx still skips.

Doc only, no behaviour here.